### PR TITLE
Added the  Event Listeners for the following new Events

### DIFF
--- a/scripts/adobe-data-layer.js
+++ b/scripts/adobe-data-layer.js
@@ -15,6 +15,15 @@ export function loadDataLayer() {
   document.addEventListener(EventNames.ASSET_QUICK_PREVIEW, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.ASSET_DETAIL, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.INFINITE_SCROLL, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.SESSION_STARTED, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.ASSET_SELECTED, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.ASSET_DESELECTED, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.ADD_ITEM_MULTISELECT, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.PREVIOUS_ASSET, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.NEXT_ASSET, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.SEARCH_RESULTS_CHANGED, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.ASSET_QUICK_PREVIEW_CLOSE, (e) => addDataLayer(e,e.detail));
+  document.addEventListener(EventNames.CLOSE_BANNER, (e) => addDataLayer(e,e.detail));
 }
 
 //Generic function to add to the adobeDataLayer

--- a/scripts/adobe-data-layer.js
+++ b/scripts/adobe-data-layer.js
@@ -19,9 +19,6 @@ export function loadDataLayer() {
   document.addEventListener(EventNames.ASSET_SELECTED, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.ASSET_DESELECTED, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.ADD_ITEM_MULTISELECT, (e) => addDataLayer(e,e.detail));
-  document.addEventListener(EventNames.PREVIOUS_ASSET, (e) => addDataLayer(e,e.detail));
-  document.addEventListener(EventNames.NEXT_ASSET, (e) => addDataLayer(e,e.detail));
-  document.addEventListener(EventNames.SEARCH_RESULTS_CHANGED, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.ASSET_QUICK_PREVIEW_CLOSE, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.CLOSE_BANNER, (e) => addDataLayer(e,e.detail));
 }


### PR DESCRIPTION
Added the  Event Listeners for the following new Events

ASSET_SELECTED: 'asset-selected'
ASSET_DESELECTED: 'asset-deselected'
ADD_ITEM_MULTISELECT: 'add-item-multiselect'
PREVIOUS_ASSET: 'previous-asset'
NEXT_ASSET: 'next-asset'
SEARCH_RESULTS_CHANGED: 'search-results-changed'
SESSION_STARTED: 'session-started'
ASSET_QUICK_PREVIEW_CLOSE: 'asset-quick-preview-close'
CLOSE_BANNER: 'close-banner'

URL for testing:
- https://assets-30051--adobe-gmo--hlxsites.hlx.page/

Screen shot of the new events in the Adobe Data Layer
![Screen Shot 2023-10-30 at 3 50 30 PM](https://github.com/hlxsites/adobe-gmo/assets/147942284/f55a488a-c0ab-4cae-8065-5f64760cb365)