### PR TITLE
Removed event  EventNames.INFINITE_SCROLL from the Adobe Data Layer

### DIFF
--- a/scripts/adobe-data-layer.js
+++ b/scripts/adobe-data-layer.js
@@ -14,7 +14,6 @@ export function loadDataLayer() {
   document.addEventListener(EventNames.FACET, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.ASSET_QUICK_PREVIEW, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.ASSET_DETAIL, (e) => addDataLayer(e,e.detail));
-  document.addEventListener(EventNames.INFINITE_SCROLL, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.SESSION_STARTED, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.ASSET_SELECTED, (e) => addDataLayer(e,e.detail));
   document.addEventListener(EventNames.ASSET_DESELECTED, (e) => addDataLayer(e,e.detail));


### PR DESCRIPTION
Removed the Event Listener EventNames.INFINATE_SCROLL from the Adobe Data Layer

Test URL

https://assets-30051--adobe-gmo--hlxsites.hlx.page/#

Screen shot of the adobeDataLayer after the user has scrolled down all the assets.
The adobeDataLayer now does not show the event : infinite-scroll

![Screen Shot 2023-11-08 at 3 57 58 PM](https://github.com/hlxsites/adobe-gmo/assets/147942284/88337bfd-d036-4782-9df0-c12e34a3a354)
