### PR TITLE
Assets 31139 - Landing page

### DIFF
--- a/blocks/gmo-footer/gmo-footer.css
+++ b/blocks/gmo-footer/gmo-footer.css
@@ -8,3 +8,7 @@
     height: 40px;
     text-transform: none;
 }
+
+.gmo-footer .copyright {
+    padding-right: 25px;
+}

--- a/blocks/gmo-footer/gmo-footer.css
+++ b/blocks/gmo-footer/gmo-footer.css
@@ -1,0 +1,10 @@
+.gmo-footer {
+    background-color: #101010;
+    color: #505050;
+    font-size: 14px;
+    display: flex;
+    flex-direction: row-reverse;
+    width: 100%;
+    height: 40px;
+    text-transform: none;
+}

--- a/blocks/gmo-footer/gmo-footer.js
+++ b/blocks/gmo-footer/gmo-footer.js
@@ -1,3 +1,3 @@
 export default function decorate(block) {
-    console.log("decorating footer");
+    block.children[0].classList.add("copyright");
 }

--- a/blocks/gmo-footer/gmo-footer.js
+++ b/blocks/gmo-footer/gmo-footer.js
@@ -1,0 +1,3 @@
+export default function decorate(block) {
+    console.log("decorating footer");
+}

--- a/blocks/gmo-landing-page/gmo-landing-page.css
+++ b/blocks/gmo-landing-page/gmo-landing-page.css
@@ -74,6 +74,10 @@
     margin-top: 25px;
 }
 
+.gmo-landing-page .video-overlay .signin-notif p {
+    margin: 0;
+}
+
 @media screen and (max-width: 1380px) {
     .gmo-landing-page .video-overlay .button.sign-in {
         margin-top: 10%;

--- a/blocks/gmo-landing-page/gmo-landing-page.css
+++ b/blocks/gmo-landing-page/gmo-landing-page.css
@@ -1,0 +1,70 @@
+.gmo-landing-page {
+    background-repeat: no-repeat;
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    text-transform: none;
+    color: #505050;
+}
+
+.gmo-landing-page .video-background {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+.gmo-landing-page .video-background video {
+    position: relative;
+    top: 0;
+    min-width: 100%;
+    min-height: 100%;
+    z-index: -1;
+    width: auto;
+    height: auto;
+}
+
+.gmo-landing-page .video-overlay {
+    position: absolute;
+    left: 0;
+    width: 45%;
+    margin-left: 5%;
+    margin-top: 10%;
+}
+
+.gmo-landing-page .video-overlay .hero-text {
+    font-size: 1.8vw;
+}
+
+.gmo-landing-page .video-overlay .logo {
+    position: relative;
+    left: -15px;
+}
+
+.gmo-landing-page .video-overlay .logo img {
+    width: 1037px;
+    height: 150px;
+}
+
+.gmo-landing-page .video-overlay .button.sign-in {
+    background-color: #1473e6;
+    border-radius: 24px;
+    border: none;
+    width: 105px;
+    height: 15px;
+    line-height: 15px;
+    font-size: 15px;
+    padding: 0.833em;
+    text-align: center;
+    margin-top: 182px;
+}
+
+.gmo-landing-page .video-overlay .button.sign-in a {
+    color: #fff;
+    font-weight: bold;
+}
+
+.gmo-landing-page .video-overlay .signin-notif {
+    font-size: 14px;
+    margin-top: 25px;
+}

--- a/blocks/gmo-landing-page/gmo-landing-page.css
+++ b/blocks/gmo-landing-page/gmo-landing-page.css
@@ -24,6 +24,11 @@
     height: auto;
 }
 
+.gmo-landing-page .video-background video.mobile {
+    display: none;
+    visibility: none;
+}
+
 .gmo-landing-page .video-overlay {
     position: absolute;
     left: 0;
@@ -40,11 +45,6 @@
     position: relative;
 }
 
-.gmo-landing-page .video-overlay .logo img {
-    width: 1037px;
-    height: 150px;
-}
-
 .gmo-landing-page .video-overlay .button.sign-in {
     background-color: #1473e6;
     border-radius: 24px;
@@ -55,8 +55,10 @@
     font-size: 15px;
     padding: 0.833em;
     text-align: center;
-    margin-top: 182px;
+    margin-top: 16.2%;
 }
+
+
 
 .gmo-landing-page .video-overlay .button.sign-in a {
     color: #fff;
@@ -70,4 +72,40 @@
 .gmo-landing-page .video-overlay .signin-notif {
     font-size: 14px;
     margin-top: 25px;
+}
+
+@media screen and (max-width: 1380px) {
+    .gmo-landing-page .video-overlay .button.sign-in {
+        margin-top: 10%;
+    }
+}
+
+@media screen and (max-width: 1050px) {
+    .gmo-landing-page .video-overlay .button.sign-in {
+        margin-top: 5%;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .gmo-landing-page {
+        flex-direction: column;
+    }
+    .gmo-landing-page .video-overlay {
+        position: relative;
+        left: unset;
+        width: unset;
+        margin: 5%;
+    }
+    .gmo-landing-page .video-overlay .hero-text {
+        font-size: unset;
+    }
+    .gmo-landing-page .video-background video.desktop {
+        display: none;
+        visibility: hidden;
+    }
+    .gmo-landing-page .video-background video.mobile {
+        display: block;
+        visibility: visible;
+    }
+
 }

--- a/blocks/gmo-landing-page/gmo-landing-page.css
+++ b/blocks/gmo-landing-page/gmo-landing-page.css
@@ -38,7 +38,6 @@
 
 .gmo-landing-page .video-overlay .logo {
     position: relative;
-    left: -15px;
 }
 
 .gmo-landing-page .video-overlay .logo img {
@@ -62,6 +61,10 @@
 .gmo-landing-page .video-overlay .button.sign-in a {
     color: #fff;
     font-weight: bold;
+}
+
+.gmo-landing-page .video-overlay .button.sign-in a:hover {
+    text-decoration: none;
 }
 
 .gmo-landing-page .video-overlay .signin-notif {

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -4,8 +4,11 @@ export default async function decorate(block) {
     const config = readBlockConfig(block);
     block.innerHTML=`
     <div class="video-background">
-        <video autoplay loop muted playsinline>
+        <video autoplay loop muted playsinline class="desktop">
             <source src="${config.videodesktop}" type="video/mp4">
+        </video>
+        <video autoplay loop muted playsinline class="mobile">
+            <source src="${config.videomobile}" type="video/mp4">
         </video>
     </div>
     <div class="video-overlay">

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -1,10 +1,8 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 
 export default async function decorate(block) {
-    //console.log(location.hostname);
     const href = location.href;
     const redirect = href.substring(0, (href.lastIndexOf("/")) + 1);
-    //console.log(redirect);
     const signInMsg = await getSignInMsg(block);
     const config = readBlockConfig(block);
     block.innerHTML=`

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -1,6 +1,9 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 
 export default async function decorate(block) {
+    //console.log("decorating");
+    const signInMsg = await getSignInMsg(block);
+    //console.log(signInMsg);
     const config = readBlockConfig(block);
     block.innerHTML=`
     <div class="video-background">
@@ -24,12 +27,18 @@ export default async function decorate(block) {
             </a>
         </div>
         <div class="signin-notif">
-            <span>${config.signinnotif[0]}</span><br>
-            <span>${config.signinnotif[1]} 
-                <a href="mailto:${config.signincontact}">
-                    ${config.signincontact}
-                </a>
-            </span>
         </div>
     </div>`
+    let msgParent = block.querySelector(".signin-notif");
+    msgParent.append(signInMsg);
+}
+
+async function getSignInMsg(block) {
+    let msgDiv;
+    block.querySelectorAll(":scope > div").forEach((div) => {
+        if (div.innerText.includes("signInNotif")) {
+            msgDiv = div.children[1]; 
+        }
+    });
+    return msgDiv;
 }

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -1,10 +1,13 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 
 export default async function decorate(block) {
-    const href = location.href;
-    const redirect = href.substring(0, (href.lastIndexOf("/")) + 1);
-    const signInMsg = await getSignInMsg(block);
+    const host = location.origin;
+    const signInMsg = getSignInMsg(block);
     const config = readBlockConfig(block);
+    console.log(config);
+    const redirect = host + config?.mainpage;
+    console.log(redirect);
+
     block.innerHTML=`
     <div class="video-background">
         <video autoplay loop muted playsinline class="desktop">
@@ -33,7 +36,7 @@ export default async function decorate(block) {
     msgParent.append(signInMsg);
 }
 
-async function getSignInMsg(block) {
+function getSignInMsg(block) {
     let msgDiv;
     block.querySelectorAll(":scope > div").forEach((div) => {
         if (div.innerText.includes("signInNotif")) {

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -4,9 +4,7 @@ export default async function decorate(block) {
     const host = location.origin;
     const signInMsg = getSignInMsg(block);
     const config = readBlockConfig(block);
-    console.log(config);
     const redirect = host + config?.mainpage;
-    console.log(redirect);
 
     block.innerHTML=`
     <div class="video-background">

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -1,6 +1,10 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 
 export default async function decorate(block) {
+    //console.log(location.hostname);
+    const href = location.href;
+    const redirect = href.substring(0, (href.lastIndexOf("/")) + 1);
+    //console.log(redirect);
     const signInMsg = await getSignInMsg(block);
     const config = readBlockConfig(block);
     block.innerHTML=`
@@ -20,7 +24,7 @@ export default async function decorate(block) {
             <span>${config.herotext}</span>
         </div>
         <div class="button sign-in">
-            <a id="button" href="${config.signinbuttonlink}">
+            <a id="button" href="${redirect}">
                 <span class="button-text">${config.signinbtntext}</span>
             </a>
         </div>

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -1,11 +1,7 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 
 export default async function decorate(block) {
-    //block.innerHTML = `<div class="gmo-landing-page-test">test</div>`
-    //console.log(block.children);
-    //console.log(readBlockConfig(block));
     const config = readBlockConfig(block);
-    console.log(config);
     block.innerHTML=`
     <div class="video-background">
         <video autoplay loop muted playsinline>

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -1,0 +1,36 @@
+import { readBlockConfig } from '../../scripts/lib-franklin.js';
+
+export default async function decorate(block) {
+    //block.innerHTML = `<div class="gmo-landing-page-test">test</div>`
+    //console.log(block.children);
+    //console.log(readBlockConfig(block));
+    const config = readBlockConfig(block);
+    console.log(config);
+    block.innerHTML=`
+    <div class="video-background">
+        <video autoplay loop muted playsinline>
+            <source src="${config.videodesktop}" type="video/mp4">
+        </video>
+    </div>
+    <div class="video-overlay">
+        <div class="logo">
+            <img src="${config.logo}" alt="Adobe Marketing Hub logo">
+        </div>
+        <div class="hero-text">
+            <span>${config.herotext}</span>
+        </div>
+        <div class="button sign-in">
+            <a id="button" href="${config.signinbuttonlink}">
+                <span class="button-text">${config.signinbtntext}</span>
+            </a>
+        </div>
+        <div class="signin-notif">
+            <span>${config.signinnotif[0]}</span><br>
+            <span>${config.signinnotif[1]} 
+                <a href="mailto:${config.signincontact}">
+                    ${config.signincontact}
+                </a>
+            </span>
+        </div>
+    </div>`
+}

--- a/blocks/gmo-landing-page/gmo-landing-page.js
+++ b/blocks/gmo-landing-page/gmo-landing-page.js
@@ -1,9 +1,7 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 
 export default async function decorate(block) {
-    //console.log("decorating");
     const signInMsg = await getSignInMsg(block);
-    //console.log(signInMsg);
     const config = readBlockConfig(block);
     block.innerHTML=`
     <div class="video-background">
@@ -29,7 +27,7 @@ export default async function decorate(block) {
         <div class="signin-notif">
         </div>
     </div>`
-    let msgParent = block.querySelector(".signin-notif");
+    const msgParent = block.querySelector(".signin-notif");
     msgParent.append(signInMsg);
 }
 

--- a/blocks/gmo-teaser/gmo-teaser.css
+++ b/blocks/gmo-teaser/gmo-teaser.css
@@ -1,0 +1,27 @@
+.gmo-teaser {
+    background-color: #101010;
+    display: flex;
+    justify-content: space-evenly;
+    width: 100%;
+    height: 280px;
+    padding-top: 20px;
+    padding-bottom: 20px;
+    text-transform: none;
+}
+
+.gmo-teaser .teaser {
+    background-color: #292929;
+    color: #efefef;
+    width: 20%;
+    border-radius: 1pc;
+    padding: 30px;
+}
+
+.gmo-teaser .teaser .title {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 15px;
+}
+.gmo-teaser .teaser .body {
+    font-size: 16px;
+}

--- a/blocks/gmo-teaser/gmo-teaser.css
+++ b/blocks/gmo-teaser/gmo-teaser.css
@@ -3,7 +3,7 @@
     display: flex;
     justify-content: space-evenly;
     width: 100%;
-    height: 280px;
+    height: 250px;
     padding-top: 20px;
     padding-bottom: 20px;
     text-transform: none;
@@ -24,4 +24,39 @@
 }
 .gmo-teaser .teaser .body {
     font-size: 16px;
+}
+
+@media screen and (max-width: 1380px) {
+    .gmo-teaser {
+        height: fit-content;
+    }
+    .gmo-teaser .teaser {
+        width: 18%;
+    }
+}
+
+@media screen and (max-width: 1050px) {
+    .gmo-teaser {
+        flex-wrap: wrap;
+        row-gap: 10px;
+    }
+    .gmo-teaser .teaser {
+        width: 39%;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .gmo-teaser {
+        row-gap: 20px;
+    }
+    .gmo-teaser .teaser {
+        width: 82%;
+        height: 250px;
+    }
+    .gmo-teaser .teaser .title {
+        font-size: 2.3vh;
+    }
+    .gmo-teaser .teaser .body {
+        font-size: 1.8vh;
+    }
 }

--- a/blocks/gmo-teaser/gmo-teaser.css
+++ b/blocks/gmo-teaser/gmo-teaser.css
@@ -54,9 +54,9 @@
         height: 250px;
     }
     .gmo-teaser .teaser .title {
-        font-size: 2.3vh;
+        font-size: var(--body-font-size-m);
     }
     .gmo-teaser .teaser .body {
-        font-size: 1.8vh;
+        font-size: var(--body-font-size-s);
     }
 }

--- a/blocks/gmo-teaser/gmo-teaser.js
+++ b/blocks/gmo-teaser/gmo-teaser.js
@@ -1,0 +1,13 @@
+import { readBlockConfig } from '../../scripts/lib-franklin.js';
+
+export default function decorate(block) {
+    console.log(block.children.length);
+    const config = readBlockConfig(block);
+    console.log(config);
+
+    Array.from(block.children).forEach((child) => {
+        child.classList.add("teaser");
+        child.children[0]?.classList.add("title");
+        child.children[1]?.classList.add("body");
+    })
+}

--- a/blocks/gmo-teaser/gmo-teaser.js
+++ b/blocks/gmo-teaser/gmo-teaser.js
@@ -1,8 +1,4 @@
-import { readBlockConfig } from '../../scripts/lib-franklin.js';
-
 export default function decorate(block) {
-    const config = readBlockConfig(block);
-
     Array.from(block.children).forEach((child) => {
         child.classList.add("teaser");
         child.children[0]?.classList.add("title");

--- a/blocks/gmo-teaser/gmo-teaser.js
+++ b/blocks/gmo-teaser/gmo-teaser.js
@@ -1,9 +1,7 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 
 export default function decorate(block) {
-    console.log(block.children.length);
     const config = readBlockConfig(block);
-    console.log(config);
 
     Array.from(block.children).forEach((child) => {
         child.classList.add("teaser");

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -232,7 +232,9 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  loadHeader(doc.querySelector('header'), 'adp-header');
+  if (!(document.querySelector('head meta[name="hide-header"]')?.getAttribute('content') === 'true')) {
+    loadHeader(doc.querySelector('header'), 'adp-header');
+  }
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   sampleRUM('lazy');

--- a/styles/gmo-styles.css
+++ b/styles/gmo-styles.css
@@ -7,3 +7,8 @@
     /* disable capitalization until ADP portal has fixed ASSETS-30971 */
     text-transform: initial;
   }
+
+header:empty {
+  display: none;
+  visibility: hidden;
+}

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,1 +1,18 @@
-{}
+{
+  "project": "marketing-hub",
+  "plugins": [
+    {
+      "id": "asset-library",
+      "title": "My Assets",
+      "environments": [
+        "edit"
+      ],
+      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+      "isPalette": true,
+      "includePaths": [
+        "**.docx**"
+      ],
+      "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
+    }
+  ]
+}

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,18 +1,1 @@
-{
-    "project": "marketing-hub",
-    "plugins": [
-      {
-        "id": "asset-library",
-        "title": "My Assets",
-        "environments": [
-          "edit"
-        ],
-        "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
-        "isPalette": true,
-        "includePaths": [
-          "**.docx**"
-        ],
-        "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
-      }
-    ]
-  }
+{}

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,1 +1,18 @@
-{}
+{
+    "project": "marketing-hub",
+    "plugins": [
+      {
+        "id": "asset-library",
+        "title": "My Assets",
+        "environments": [
+          "edit"
+        ],
+        "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+        "isPalette": true,
+        "includePaths": [
+          "**.docx**"
+        ],
+        "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
+      }
+    ]
+  }


### PR DESCRIPTION
Added three new blocks:

1. gmo-landing-page
2. gmo-teaser
3. gmo-footer

Also added a metadata property "hide-header" (and updated scripts.js header-loading logic) that allows us to implement a page without the adp header.

When assembled in a document they can replicate the landing page from the AEM Sites version of Marketing Hub/GenStudio.

Styling includes mobile breakpoints for adjusting font size/layout/the video that appears in the page background.

URL for testing:
- https://assets-31139--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/landing-page