### PR TITLE
Assets 32164

### DIFF
--- a/head.html
+++ b/head.html
@@ -13,6 +13,7 @@
 <link rel="stylesheet" href="/scripts/libs/flatpickr/flatpickr.min.css">
 <!-- End of Generated code -->
 <script src="/scripts/scripts.js" type="module"></script>
+<script src="/scripts/custom-scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="stylesheet" href="/styles/gmo-styles.css"/>
 <link rel="icon" href="data:,">

--- a/scripts/custom-scripts.js
+++ b/scripts/custom-scripts.js
@@ -6,7 +6,6 @@ initLegalNotice();
 
 async function initLegalNotice() {
     const config = await getBrandingConfig();
-    console.log(config);
     document.addEventListener(EventNames.SESSION_STARTED, function() {
       showLegalNotice(config);
     });

--- a/scripts/custom-scripts.js
+++ b/scripts/custom-scripts.js
@@ -1,0 +1,22 @@
+import { getBrandingConfig } from "./site-config.js";
+import { EventNames } from "./events.js";
+import showToast from "./toast-message.js";
+
+initLegalNotice();
+
+async function initLegalNotice() {
+    const config = await getBrandingConfig();
+    console.log(config);
+    document.addEventListener(EventNames.SESSION_STARTED, function() {
+      showLegalNotice(config);
+    });
+}
+  
+function showLegalNotice(config) {
+    const legalDefault = `NOTICE: Adobe records and uses your e-mail address for tracking purposes.`;
+    const legalToast = config?.legalMessage || legalDefault;
+    const legalDuration = 10000;
+    const toastType = "info";
+
+    showToast(legalToast, legalDuration, toastType, false);
+}

--- a/styles/gmo-styles.css
+++ b/styles/gmo-styles.css
@@ -16,3 +16,7 @@ header:empty {
 header nav .nav-brand .adp-logo img {
   min-height: 42px;
 }
+
+.adp-toast {
+  text-transform: none;
+}


### PR DESCRIPTION
- new branch
- small change to immutable(?) head.html
- 'custom-scripts.js' file with functions to enable the legal banner

Authors can add a 'legal-message' property to their branding config that controls the text of the toast message.

JIRA: ASSETS-32164

Test URLs:
https://assets-32164--adobe-gmo--hlxsites.hlx.page/sample-public-site
