### PR TITLE
ASSETS-32307: updated metrics report with latest numbers

### DIFF
--- a/blocks/adp-metrics/adp-metrics.js
+++ b/blocks/adp-metrics/adp-metrics.js
@@ -6,20 +6,20 @@ import { logError } from '../../scripts/scripts.js';
 
 const GENERAL_METRICS = [{
   category: 'Total assets',
-  amount: 10118,
+  amount: 59475,
 }, {
   category: 'Total size',
-  amount: 1024 * 1024 * 1024 * 209,
+  amount: 1024 * 1024 * 1024 * 331.6,
   unit: 'bytes',
 }, {
   category: 'Uploads year-to-date',
-  amount: 10118,
+  amount: 59475,
 }, {
   category: 'Uploads quarter-to-date',
-  amount: 6620,
+  amount: 56629,
 }, {
   category: 'Uploads last 30 days',
-  amount: 6462,
+  amount: 56486,
 }];
 
 function formatNumber(number) {
@@ -57,31 +57,31 @@ function formatAmount(metric) {
 }
 
 const MIME_TYPES = [
-  { category: 'video/mp4', amount: 3582 },
-  { category: 'image/jpeg', amount: 2391 },
-  { category: 'image/png', amount: 2053 },
-  { category: 'video/quicktime', amount: 424 },
+  { category: 'video/mp4', amount: 3579 },
+  { category: 'image/jpeg', amount: 51258 },
+  { category: 'image/png', amount: 2102 },
+  { category: 'video/quicktime', amount: 422 },
   { category: 'image/vnd.adobe.photoshop', amount: 380 },
   { category: 'audio/x-wav', amount: 104 },
   { category: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', amount: 102 },
-  { category: 'application/vnd.adobe.sparkler.project+dcx', amount: 102 },
-  { category: 'application/pdf', amount: 92 },
+  { category: 'application/vnd.adobe.sparkler.project+dcx', amount: 578 },
+  { category: 'application/pdf', amount: 571 },
   { category: 'application/octet-stream', amount: 48 },
   { category: 'application/postscript', amount: 33 },
   { category: 'application/json', amount: 30 },
   { category: 'application/vnd.audiograph', amount: 19 },
   { category: 'application/x-subrip', amount: 18 },
-  { category: 'application/vnd.openxmlformats-officedocument.presentationml.presentation', amount: 16 },
-  { category: 'application/zip', amount: 13 },
-  { category: 'image/svg+xml', amount: 12 },
+  { category: 'application/vnd.openxmlformats-officedocument.presentationml.presentation', amount: 15 },
+  { category: 'application/zip', amount: 21 },
+  { category: 'image/svg+xml', amount: 9 },
   { category: 'image/gif', amount: 11 },
   { category: 'application/vnd.3gpp.pic-bw-small', amount: 9 },
   { category: 'video/ogg', amount: 9 },
   { category: 'image/tiff', amount: 8 },
-  { category: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', amount: 7 },
+  { category: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', amount: 170 },
   { category: 'audio/mpeg', amount: 4 },
   { category: 'text/html', amount: 3 },
-  { category: 'text/plain', amount: 3 },
+  { category: 'text/plain', amount: 2 },
 ];
 
 const BUSINESS_UNITS = [{


### PR DESCRIPTION
Updates the asset metrics dashboard with recent statistics for general information and by asset type.

JIRA: ASSETS-32307

Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->
- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://metrics-update--assets-distribution-portal--adobe.hlx.page/sample-public-site
