### PR TITLE
Assets 32396

### DIFF
--- a/scripts/site-config.js
+++ b/scripts/site-config.js
@@ -281,6 +281,8 @@ export async function getQuickLinkConfig() {
       });
     }
   });
+  console.log("Kaleidoscope");
+  console.log(result);
   return result;
 }
 

--- a/scripts/site-config.js
+++ b/scripts/site-config.js
@@ -272,17 +272,26 @@ async function mapUserSettingsForId(configId, result) {
  */
 export async function getQuickLinkConfig() {
   const result = [];
+  let faqPage = null;
   const response = await getConfig('site-config.json');
   response.quicklinks?.data.forEach((row) => {
     if (row.Title && row.Page) {
-      result.push({
-        title: row.Title,
-        page: row.Page,
-      });
+      if (row.Title === 'FAQ') {
+        faqPage = {
+          title: row.Title,
+          page: row.Page,
+        };
+      } else {
+        result.push({
+          title: row.Title,
+          page: row.Page,
+        });
+      }
     }
   });
-  console.log("Kaleidoscope");
-  console.log(result);
+  if (faqPage) {
+    result.push(faqPage);
+  }
   return result;
 }
 


### PR DESCRIPTION
JIRA: [ASSETS-32396](https://jira.corp.adobe.com/browse/ASSETS-32396)

Made changes to getQuickLinkConfig() in site-config.js in order to place the FAQ link (if found) in the Quick Links section of the header to the last position. Tested locally, but as per below, Test URLs do not yet function on pages that require authentication.

Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->
- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://ASSETS-32396--adobe-gmo--hlxsites.hlx.page/sample-public-site
