### PR TITLE
update date detection functionality

### DIFF
--- a/scripts/metadata.js
+++ b/scripts/metadata.js
@@ -338,17 +338,19 @@ const DATA_TYPES = {
 function isDateValue(value) {
   if (typeof value === 'object' && value instanceof Date) {
     return true;
-  } if (typeof value === 'string') {
-    return !Number.isNaN(Date.parse(value)) || false;
-  } if (typeof value === 'number') {
-    try {
-      const date = new Date(value);
-      return !Number.isNaN(date.getTime());
-    } catch (e) {
-      return false;
-    }
+  } if (typeof value === 'string' || typeof value === 'number') {
+    return isISODate(value);
   }
   return false;
+}
+
+function isISODate(value) {
+  const dateObj = new Date(value);
+  try {
+    return (dateObj !== 'Invalid Date' && !Number.isNaN(dateObj) && (value === dateObj.toISOString())) || false;
+  } catch (e) {
+    return false;
+  }
 }
 
 export function isDate(propertyName, propertyValue) {
@@ -398,7 +400,7 @@ export function formatAssetMetadata(propertyName, metadataValue) {
   }
 
   // check if string is a date
-  if (Date.parse(metadataValue)) {
+  if (isISODate(metadataValue)) {
     return formatDate(metadataValue);
   }
 


### PR DESCRIPTION
Date.parse() was producing inconsistent results and falsely identifying strings with numbers (ex: 'Black Friday 2023') as dates. Since actual dates returned by Polaris adhere to ISO formatting, compare inspected values to ISO formatting to determine validity as a date.

JIRA: ASSETS-32392

Test URLs:
https://assets-32392--adobe-gmo--hlxsites.hlx.page/sample-public-site
