### PR TITLE
Assets 32349

### DIFF
--- a/blocks/adp-header/adp-header.js
+++ b/blocks/adp-header/adp-header.js
@@ -106,15 +106,13 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
 export default async function decorate(block) {
   block.textContent = '';
   
-  // Kaleidoscope
+  // change adp-logo href depending on whether user is logged in
   let logoHome = null;
-
   if (await window.adobeIMS?.getProfile() != null) {
     logoHome = `${getBaseConfigPath()}/` + 'assets';
   } else {
     logoHome = `${getBaseConfigPath()}/`;
   }
-  console.log(logoHome);
 
   // decorate nav DOM
   const nav = document.createElement('nav');

--- a/blocks/adp-header/adp-header.js
+++ b/blocks/adp-header/adp-header.js
@@ -105,13 +105,24 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
  */
 export default async function decorate(block) {
   block.textContent = '';
+  
+  // Kaleidoscope
+  let logoHome = null;
+
+  if (await window.adobeIMS?.getProfile() != null) {
+    logoHome = `${getBaseConfigPath()}/` + 'assets';
+  } else {
+    logoHome = `${getBaseConfigPath()}/`;
+  }
+  console.log(logoHome);
+
   // decorate nav DOM
   const nav = document.createElement('nav');
   nav.id = 'nav';
   nav.innerHTML = `
   <div class="nav-top">
     <div class="nav-brand">
-      <a class="adp-logo" href="/"></a>
+      <a class="adp-logo" href="${logoHome}"></a>
       <div></div>
     </div>
     <div class="nav-sections">

--- a/blocks/adp-header/adp-header.js
+++ b/blocks/adp-header/adp-header.js
@@ -347,7 +347,7 @@ function initQuickLinks() {
 
   // set aria-selected on quick links
   quickLinks.querySelectorAll('.item').forEach((item) => {
-    if (item.querySelector('a')?.dataset.page === window.location.pathname) {
+    if (item.querySelector('a')?.getAttribute('href') === window.location.pathname) {
       item.setAttribute('aria-selected', 'true');
     }
   });


### PR DESCRIPTION
JIRA: [ASSETS-32349](https://jira.corp.adobe.com/browse/ASSETS-32349)

Made changes to dynamically set the href of the adp-logo depending on whether the user is logged in and/or whether the user is navigating the /qa section of the site. 

A bug that prevented quick-links in /qa from being selected was also resolved.

![Screenshot 2024-01-03 112643](https://github.com/hlxsites/adobe-gmo/assets/147882114/0092b502-41d8-4bd8-9e80-e09c6d1df3e8)


Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->
- Before: https://main--adobe-gmo--adobe.hlx.page/sample-public-site
- After: https://assets-32349--adobe-gmo--adobe.hlx.page/sample-public-site
