### PR TITLE
Assets 34038

### DIFF
--- a/blocks/adp-header/adp-header.js
+++ b/blocks/adp-header/adp-header.js
@@ -106,21 +106,13 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
 export default async function decorate(block) {
   block.textContent = '';
   
-  // change adp-logo href depending on whether user is logged in
-  let logoHome = null;
-  if (await window.adobeIMS?.getProfile() != null) {
-    logoHome = `${getBaseConfigPath()}/` + 'assets';
-  } else {
-    logoHome = `${getBaseConfigPath()}/`;
-  }
-
   // decorate nav DOM
   const nav = document.createElement('nav');
   nav.id = 'nav';
   nav.innerHTML = `
   <div class="nav-top">
     <div class="nav-brand">
-      <a class="adp-logo" href="${logoHome}"></a>
+      <a class="adp-logo" href="${getBaseConfigPath()}/"></a>
       <div></div>
     </div>
     <div class="nav-sections">
@@ -228,7 +220,8 @@ export default async function decorate(block) {
     }
   });
 
-  if (!isPublicPage()) {
+  if (await getUserProfile() != null) {
+    document.querySelector('.adp-logo').href = getBaseConfigPath() + '/assets';
     loadSearchField(nav);
     await createUserInfo(nav);
     initQuickLinks();

--- a/blocks/adp-header/adp-header.js
+++ b/blocks/adp-header/adp-header.js
@@ -220,7 +220,7 @@ export default async function decorate(block) {
     }
   });
 
-  if (await getUserProfile() != null) {
+  if (await getUserProfile() !== null) {
     document.querySelector('.adp-logo').href = getBaseConfigPath() + '/assets';
     loadSearchField(nav);
     await createUserInfo(nav);

--- a/scripts/security-imslib.js
+++ b/scripts/security-imslib.js
@@ -1,6 +1,7 @@
 import { loadScript } from './lib-franklin.js';
 import { getAdminConfig } from './site-config.js';
 import { fetchCached } from './fetch-util.js';
+import { isPublicPage } from './security.js';
 
 let isIMSInitialized = false;
 
@@ -25,7 +26,7 @@ async function getBearerTokenFromIMS(callWithToken) {
   }
   if (!isIMSInitialized) {
     window.adobeid = {
-      client_id: IMSLIB_ENV_CONFIG.clientId,
+      client_id: imsLibConfig.clientId,
       scope: IMSLIB_ENV_CONFIG.scope,
       locale: 'en_US',
       autoValidateToken: true,
@@ -40,7 +41,9 @@ async function getBearerTokenFromIMS(callWithToken) {
           const token = tokenDetails && tokenDetails.token;
           callWithToken(token);
         } else {
-          window.adobeIMS.reAuthenticate();
+          if (!isPublicPage()) {
+              window.adobeIMS.reAuthenticate();
+          }
         }
       },
     };

--- a/scripts/security-imslib.js
+++ b/scripts/security-imslib.js
@@ -40,10 +40,10 @@ async function getBearerTokenFromIMS(callWithToken) {
           }
           const token = tokenDetails && tokenDetails.token;
           callWithToken(token);
-        } else {
-          if (!isPublicPage()) {
+          return;
+        } 
+        if (!isPublicPage()) {
               window.adobeIMS.reAuthenticate();
-          }
         }
       },
     };
@@ -51,9 +51,9 @@ async function getBearerTokenFromIMS(callWithToken) {
     // load ims.min.js
     await loadScript(IMSLIB_ENV_CONFIG.urls[imsLibConfig.imsEnvironment]);
     isIMSInitialized = true;
-  } else {
-    window.adobeIMS.reAuthenticate();
+    return;
   }
+    window.adobeIMS.reAuthenticate();
 }
 
 /**

--- a/scripts/security.js
+++ b/scripts/security.js
@@ -52,13 +52,13 @@ export function isPublicPage() {
 }
 
 export async function checkUserAccess() {
-  if (isPublicPage()) {
-    return true;
-  }
   await getBearerToken();
   const { imsUserGroup } = await getIMSConfig();
   if (imsUserGroup) {
     const imsLibSecurityModule = await import('./security-imslib.js');
+    if (isPublicPage()) {
+      return true;
+    } 
     return await imsLibSecurityModule.isUserInSecurityGroup(imsUserGroup, await getBearerToken());
   }
   return true;


### PR DESCRIPTION

JIRA: [ASSETS-34038](https://jira.corp.adobe.com/browse/ASSETS-34038)

- Made changes to checkUserAccess() that will allow login status to be checked even on pages where isPublicPage() is true

- Changed client_id to use imsLibConfig in case sharepoint is used for this purpose in the future

- Changes to getBearerTokenFromIMS() made so that window.adobeIMS.reAuthenticate() only runs on non public pages

- Simplified method of changing the adp-logo href using the ability to check user logged in status

- Header now loads quicklinks, searchfield and userinfo based on user login status, allowing quicklinks and userinfo to appear on public pages if logged in.


Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->
- Before: https://main--adobe-gmo--hlxsites.hlx.page/sample-public-site
- After: https://ASSETS-34038--adobe-gmo--hlxsites.hlx.page/sample-public-site
