### PR TITLE
Create .hlxignore

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -1,0 +1,7 @@
+.*
+*.md
+karma.config.js
+LICENSE
+package.json
+package-lock.json
+test/*


### PR DESCRIPTION
At some point the .hlxignore file seemed to have been removed or omitted from git on accident.  I am re-adding it.

The .hlxignore file prevents internal files from being synched with the Helix code bus (similar to .gitignore). Here's the example from the aem-boilerplate project: https://github.com/adobe/aem-boilerplate/blob/main/.hlxignore
Your project is based on the boilerplate but someone must have deleted .hlxignore . As a result your project is leaking e.g. package(-lock).json which I assume is not intentional.