### PR TITLE
Modified formatAssetMetadata() to allow custom dc-format Labels

### DIFF
--- a/scripts/metadata.js
+++ b/scripts/metadata.js
@@ -378,11 +378,6 @@ export function formatAssetMetadata(propertyName, metadataValue) {
     return DATA_TYPES.tags(metadataValue, propertyName);
   }
 
-  // file types
-  if (['dc-format'].includes(propertyName)) {
-    return PREDEFINED_METADATA_FIELDS.format.format(metadataValue);
-  }
-
   // dates
   if (isDate(propertyName, metadataValue)) {
     return formatDate(metadataValue);


### PR DESCRIPTION
JIRA: [ASSETS-35142](https://jira.corp.adobe.com/browse/ASSETS-35142)

Removed the existing formatting for file format (dc-format) search facet labels in order to utilize the sharepoint custom metadata label functionality.

Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->
- Before: https://main--adobe-gmo--hlxsites.hlx.page/
- After: https://assets-35142--adobe-gmo--hlxsites.hlx.page/