### PR TITLE
ASSETS-88888  : Add 'Select All' button on Collections Details and Share Link Page

### DIFF
--- a/blocks/adp-collection-header/adp-collection-header.css
+++ b/blocks/adp-collection-header/adp-collection-header.css
@@ -20,8 +20,15 @@
     z-index: 1;
 }
 
+
 .adp-collection-header-left .adp-collection-title {
-    margin-bottom: 12px;
+    margin-bottom: 12px; /* Keeps space between title and items */
+}
+
+.adp-collection-subinfo {
+    display: flex;
+    /* justify-content: space-between; /* Aligns items to the left and select all to the right */
+    align-items: center; /* Centers items vertically */
 }
 
 .adp-collection-stats {
@@ -29,13 +36,30 @@
     border-radius: 6px;
     font: 11px/14px var(--body-font-family);
     padding: 6px 10px;
-    width: fit-content;
+    flex-shrink: 0;
+    margin-right: 20px; /* Adjust the 20px to whatever fixed space you want between the items and the checkbox */
 }
+
+.adp-collection-select-all {
+    display: flex;
+    align-items: center; /* This will vertically align the checkbox and label */
+}
+
+.adp-collection-select-all input[type="checkbox"] {
+    margin-right: 5px; /* Adds some space between the checkbox and the label */
+}
+
 
 .adp-collection-header-left .back-button .icon {
     height: 10px;
     width: 18px;
     vertical-align: text-bottom;
+}
+
+/*Todo New CSS */
+.adp-collection-header-collection-info {
+    display: flex;
+    flex-direction: column; /* Stack the title and sub-info vertically */
 }
 
 .adp-collection-header .adp-collection-title {

--- a/blocks/adp-collection-header/adp-collection-header.js
+++ b/blocks/adp-collection-header/adp-collection-header.js
@@ -3,6 +3,11 @@ import createConfirmDialog from '../../scripts/confirm-dialog.js';
 import { decorateIcons } from '../../scripts/lib-franklin.js';
 import { createLinkHref, navigateTo } from '../../scripts/scripts.js';
 
+import {
+  selectAllAssets,deselectAllAssets,
+} from '../adp-infinite-results-collection/adp-infinite-results-collection.js';
+
+
 function createCollectionInfoHeader(collectionInfoHeader, collection) {
   // include back to collections listing similar to hide filters button
   collectionInfoHeader.innerHTML = `
@@ -14,6 +19,10 @@ function createCollectionInfoHeader(collectionInfoHeader, collection) {
             <div class="adp-collection-title"></div>
             <div class="adp-collection-subinfo">
               <div class="adp-collection-stats"></div>
+              <div class="adp-collection-select-all">
+                <input type="checkbox" id="select-all-checkbox"/>
+                <label for="select-all-checkbox">Select All</label>
+              </div>
             </div>
           </div>
         </div>
@@ -28,6 +37,16 @@ function createCollectionInfoHeader(collectionInfoHeader, collection) {
   const backButton = collectionInfoHeader.querySelector('.back-button a');
   backButton.href = createLinkHref(backButton.href);
 
+  document.getElementById('select-all-checkbox').addEventListener('click', function(event) {
+      // Get the checked state of the select all checkbox
+      var isChecked = event.target.checked;
+
+      // Get all the checkboxes within the cards
+      var checkboxes = document.querySelectorAll('.checkbox-container input[type="checkbox"], .filetype-video .checkbox-container input[type="checkbox"]');
+      // isChecked then selectAllAssets() else deselectAllAssets
+      isChecked ? selectAllAssets() : deselectAllAssets();
+  });
+
   collectionInfoHeader.querySelector('.action-collection-delete').addEventListener('click', async (e) => {
     e.preventDefault();
     const collectionId = getCollectionIdFromURL();
@@ -36,7 +55,7 @@ function createCollectionInfoHeader(collectionInfoHeader, collection) {
         'Delete collection',
         `Are you sure you want to delete the collection "${collection.title}"?`,
         async () => {
-          await deleteCollection(collectionId, collection.title);
+          await deleteCollection(collectionId, collection.title, collection.etag);
           navigateTo(createLinkHref('/collections'));
         },
         'Proceed',

--- a/blocks/adp-infinite-results-collection/adp-infinite-results-collection.js
+++ b/blocks/adp-infinite-results-collection/adp-infinite-results-collection.js
@@ -39,3 +39,12 @@ export function hasNextCard() {
 export function hasPreviousCard() {
   return infiniteResultsContainer.hasPreviousCard();
 }
+
+
+export function selectAllAssets() {
+  infiniteResultsContainer.selectAllItems();
+}
+
+export function deselectAllAssets() {
+  infiniteResultsContainer.deselectAllItems();
+}

--- a/blocks/adp-infinite-results-linkshare/adp-infinite-results-linkshare.js
+++ b/blocks/adp-infinite-results-linkshare/adp-infinite-results-linkshare.js
@@ -8,6 +8,7 @@ export default async function decorate(block) {
   const instantSearchDatasource = new LinkShareDatasource();
   infiniteResultsContainer = new InfiniteResultsContainer(block, instantSearchDatasource);
   infiniteResultsContainer.render();
+
   addEventListener(EventNames.ASSET_QUICK_PREVIEW_CLOSE, (e) => {
     infiniteResultsContainer.deselectItem(e.detail.assetId);
   });
@@ -21,3 +22,13 @@ export function openLinkShare(id) {
   // change the url
   window.history.pushState({}, '', url);
 }
+
+export function selectAllAssets() {
+  infiniteResultsContainer.selectAllItems();
+}
+
+export function deselectAllAssets() {
+  infiniteResultsContainer.deselectAllItems();
+}
+
+

--- a/blocks/adp-share-header/adp-share-header.css
+++ b/blocks/adp-share-header/adp-share-header.css
@@ -1,0 +1,88 @@
+.section.adp-share-header-left-container {
+    padding-right: 0;
+}
+
+/*
+.adp-share-header {
+    display: flex;
+    height: 124px;
+}
+
+*/
+.adp-share-header{
+  /*grid-area: selection-items; */
+  /* display: flex; */
+  padding-top: 15px;
+  padding-bottom: 11px;
+}
+
+.adp-share-header-left {
+    display: flex;
+    gap: 15px;
+    align-items: center;
+    width: 100%;
+    font-size: var(--header-font-size);
+    padding: 0;
+    top: 0.01rem;
+    padding-top: 0.88rem;
+    padding-bottom: 0.88rem;
+    z-index: 1;
+}
+
+.adp-share-header-left .adp-share-title {
+    margin-bottom: 12px; /* Keeps space between title and items */
+}
+
+.adp-share-subinfo {
+    display: flex;
+    justify-content: space-between; /* Aligns items to the left and select all to the right */
+    align-items: center; /* Centers items vertically */
+}
+
+.adp-share-stats {
+    border: #E6E6E6 1px solid;
+    border-radius: 6px;
+    font: 11px/14px var(--body-font-family);
+    padding: 6px 10px;
+    flex-shrink: 0;
+}
+
+
+.adp-share-select-all {
+    display: flex;
+    align-items: center; /* This will vertically align the checkbox and label */
+}
+
+.adp-share-select-all input[type="checkbox"] {
+    margin-right: 5px; /* Adds some space between the checkbox and the label */
+}
+
+
+.adp-share-header-left .back-button .icon {
+    height: 10px;
+    width: 18px;
+    vertical-align: text-bottom;
+}
+
+/*Todo New CSS */
+.adp-share-header-share-info {
+    display: flex;
+    flex-direction: column; /* Stack the title and sub-info vertically */
+}
+
+.adp-share-header .adp-share-title {
+    font: var(--share-heading-font);
+    width: 100%;
+}
+
+.adp-share-header .actions .adp-action {
+    text-wrap: nowrap;
+    align-items: center;
+}
+
+.adp-share-header .actions {
+    /* vertically align center */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/blocks/adp-share-header/adp-share-header.css
+++ b/blocks/adp-share-header/adp-share-header.css
@@ -2,18 +2,9 @@
     padding-right: 0;
 }
 
-/*
 .adp-share-header {
     display: flex;
-    height: 124px;
-}
-
-*/
-.adp-share-header{
-  /*grid-area: selection-items; */
-  /* display: flex; */
-  padding-top: 15px;
-  padding-bottom: 11px;
+    height: 62px;
 }
 
 .adp-share-header-left {
@@ -29,13 +20,14 @@
     z-index: 1;
 }
 
+/*
 .adp-share-header-left .adp-share-title {
     margin-bottom: 12px; /* Keeps space between title and items */
 }
-
+*/
 .adp-share-subinfo {
     display: flex;
-    justify-content: space-between; /* Aligns items to the left and select all to the right */
+    /* justify-content: space-between; /* Aligns items to the left and select all to the right */
     align-items: center; /* Centers items vertically */
 }
 
@@ -45,8 +37,8 @@
     font: 11px/14px var(--body-font-family);
     padding: 6px 10px;
     flex-shrink: 0;
+    margin-right: 20px; /* Adjust the 20px to whatever fixed space you want between the items and the checkbox */
 }
-
 
 .adp-share-select-all {
     display: flex;
@@ -57,21 +49,13 @@
     margin-right: 5px; /* Adds some space between the checkbox and the label */
 }
 
-
-.adp-share-header-left .back-button .icon {
-    height: 10px;
-    width: 18px;
-    vertical-align: text-bottom;
-}
-
-/*Todo New CSS */
 .adp-share-header-share-info {
     display: flex;
     flex-direction: column; /* Stack the title and sub-info vertically */
 }
 
 .adp-share-header .adp-share-title {
-    font: var(--share-heading-font);
+    font: var(--collection-heading-font);
     width: 100%;
 }
 

--- a/blocks/adp-share-header/adp-share-header.css
+++ b/blocks/adp-share-header/adp-share-header.css
@@ -20,11 +20,6 @@
     z-index: 1;
 }
 
-/*
-.adp-share-header-left .adp-share-title {
-    margin-bottom: 12px; /* Keeps space between title and items */
-}
-*/
 .adp-share-subinfo {
     display: flex;
     /* justify-content: space-between; /* Aligns items to the left and select all to the right */

--- a/blocks/adp-share-header/adp-share-header.js
+++ b/blocks/adp-share-header/adp-share-header.js
@@ -3,16 +3,16 @@ import createConfirmDialog from '../../scripts/confirm-dialog.js';
 import { decorateIcons } from '../../scripts/lib-franklin.js';
 import { createLinkHref, navigateTo } from '../../scripts/scripts.js';
 
+import {
+  selectAllAssets, deselectAllAssets
+} from '../adp-infinite-results-linkshare/adp-infinite-results-linkshare.js';
 
 function createShareInfoHeader(shareInfoHeader) {
 
   shareInfoHeader.innerHTML = `
         <div class="adp-share-header-left">
-
           <div class="adp-share-header-share-info">
-            <div class="adp-share-title"></div>
             <div class="adp-share-subinfo">
-              <div class="adp-share-stats"></div>
               <div class="adp-share-select-all">
                 <input type="checkbox" id="select-all-checkbox"/>
                 <label for="select-all-checkbox">Select All</label>
@@ -22,8 +22,6 @@ function createShareInfoHeader(shareInfoHeader) {
         </div>
         </div>
     `;
-  //shareInfoHeader.querySelector('.adp-share-title').innerText = 'title';
-  shareInfoHeader.querySelector('.adp-share-stats').innerText = '5 items';
 
   document.getElementById('select-all-checkbox').addEventListener('click', function(event) {
       // Get the checked state of the select all checkbox
@@ -31,11 +29,8 @@ function createShareInfoHeader(shareInfoHeader) {
 
       // Get all the checkboxes within the cards
       var checkboxes = document.querySelectorAll('.checkbox-container input[type="checkbox"], .filetype-video .checkbox-container input[type="checkbox"]');
-
-      // Set the checked state of each card's checkbox to match the select all checkbox
-      checkboxes.forEach(function(checkbox) {
-          checkbox.checked = isChecked;
-      });
+      // isChecked then selectAllAssets() else deselectAllAssets
+      isChecked ? selectAllAssets() : deselectAllAssets();
   });
 
   decorateIcons(shareInfoHeader);

--- a/blocks/adp-share-header/adp-share-header.js
+++ b/blocks/adp-share-header/adp-share-header.js
@@ -1,0 +1,48 @@
+
+import createConfirmDialog from '../../scripts/confirm-dialog.js';
+import { decorateIcons } from '../../scripts/lib-franklin.js';
+import { createLinkHref, navigateTo } from '../../scripts/scripts.js';
+
+
+function createShareInfoHeader(shareInfoHeader) {
+
+  shareInfoHeader.innerHTML = `
+        <div class="adp-share-header-left">
+
+          <div class="adp-share-header-share-info">
+            <div class="adp-share-title"></div>
+            <div class="adp-share-subinfo">
+              <div class="adp-share-stats"></div>
+              <div class="adp-share-select-all">
+                <input type="checkbox" id="select-all-checkbox"/>
+                <label for="select-all-checkbox">Select All</label>
+              </div>
+            </div>
+          </div>
+        </div>
+        </div>
+    `;
+  //shareInfoHeader.querySelector('.adp-share-title').innerText = 'title';
+  shareInfoHeader.querySelector('.adp-share-stats').innerText = '5 items';
+
+  document.getElementById('select-all-checkbox').addEventListener('click', function(event) {
+      // Get the checked state of the select all checkbox
+      var isChecked = event.target.checked;
+
+      // Get all the checkboxes within the cards
+      var checkboxes = document.querySelectorAll('.checkbox-container input[type="checkbox"], .filetype-video .checkbox-container input[type="checkbox"]');
+
+      // Set the checked state of each card's checkbox to match the select all checkbox
+      checkboxes.forEach(function(checkbox) {
+          checkbox.checked = isChecked;
+      });
+  });
+
+  decorateIcons(shareInfoHeader);
+  return shareInfoHeader;
+}
+
+export default async function decorate(block) {
+  block.innerHTML = '';
+  createShareInfoHeader(block);
+}


### PR DESCRIPTION
No Jira Ticket has been created for this task
Here is the Workfront Ticket
https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/team/64120499002edcb6e4ef1dbc3e644241/iterations


Test URLs:

- Before: https://main--adobe-gmo--hlxsites.hlx.page/

For Collection Detail with Select All
- After: https://assets-88888--adobe-gmo--hlxsites.hlx.page/collection/urn_cid_aem_0311ed8d-4e8d-46bd-83f6-af89f8e9d11a

For Share Link with Select All

https://assets-88888--adobe-gmo--hlxsites.hlx.page/qa/share/1db300fb-db2d-4f51-8705-814514973aa0

**Authoring instructions.**
Edit the asset-distribution-portal>share>default.docx page and add the block adp-share-header

![Screenshot 2024-03-01 at 2 36 38 PM](https://github.com/hlxsites/adobe-gmo/assets/147942284/14654969-91d4-4ced-967a-48a4065d8da4)


