### PR TITLE
'Add Assets' button can now be hidden by IMS group

### DIFF
--- a/blocks/adp-assets-actions/adp-assets-actions.js
+++ b/blocks/adp-assets-actions/adp-assets-actions.js
@@ -1,13 +1,14 @@
 import { openUploadDialog } from '../../contenthub/hydration/hydration.js';
 import { decorateIcons } from '../../scripts/lib-franklin.js';
+import { checkAddAssetsAccess } from '../../scripts/security.js';
 import { isContentHub } from '../../scripts/site-config.js';
 
 export default async function decorate(block) {
   block.innerHTML = '';
   const assetActionsDiv = document.createElement('div');
   assetActionsDiv.className = 'actions-container';
-  // add Asset actions button
-  if (await isContentHub()) {
+  //add Asset actions button
+  if (await isContentHub() && await checkAddAssetsAccess()) {
     const addAssetsButton = document.createElement('button');
     addAssetsButton.classList.add('action', 'add-assets');
     const addAssetsSpan = document.createElement('span');

--- a/blocks/adp-header/adp-header.js
+++ b/blocks/adp-header/adp-header.js
@@ -4,7 +4,7 @@ import {
 import {
   getBrandingConfig, getQuickLinkConfig, isUrlPathNonRoot, getBaseConfigPath,
 } from '../../scripts/site-config.js';
-import { getUserProfile, getAvatarUrl, isPublicPage } from '../../scripts/security.js';
+import { getUserProfile, getAvatarUrl, isPublicPage, checkAddAssetsAccess } from '../../scripts/security.js';
 import { closeDialogEvent, createLinkHref, getSelectedAssetsFromInfiniteResultsBlock } from '../../scripts/shared.js';
 import { EventNames, addEventListener, emitEvent } from '../../scripts/events.js';
 import { openShareModalMultiSelectedAssets } from '../adp-share-modal/adp-share-modal.js';
@@ -315,7 +315,7 @@ async function handleRemoveMultiSelectedAssetsFromCollection() {
   window.location.reload();
 }
 
-function initQuickLinks() {
+async function initQuickLinks() {
   if (document.querySelector('head meta[name="hide-quicklinks"]')?.getAttribute('content') === 'true') {
     return;
   }
@@ -341,18 +341,19 @@ function initQuickLinks() {
     quickLinks.append(itemEl);
   });
 
-  const navDiv = document.createElement('div');
-  navDiv.classList.add('item');
-  const addAssetsButton = document.createElement('button');
-  addAssetsButton.classList.add('action', 'add-assets');
-  navDiv.appendChild(addAssetsButton);
-  addAssetsButton.appendChild(document.createTextNode('Add Assets'));
-  addAssetsButton.addEventListener('click', () => {
-    openUploadDialog();
-  });
-  quickLinks.appendChild(navDiv);
-
-  // set aria-selected on quick links
+  if (await checkAddAssetsAccess()) {
+    const navDiv = document.createElement('div');
+    navDiv.classList.add('item');
+    const addAssetsButton = document.createElement('button');
+    addAssetsButton.classList.add('action', 'add-assets');
+    navDiv.appendChild(addAssetsButton);
+    addAssetsButton.appendChild(document.createTextNode('Add Assets'));
+    addAssetsButton.addEventListener('click', () => {
+      openUploadDialog();
+    });
+    quickLinks.appendChild(navDiv);
+  }
+  //set aria-selected on quick links
   quickLinks.querySelectorAll('.item').forEach((item) => {
     if (item.querySelector('a')?.dataset.page === window.location.pathname) {
       item.setAttribute('aria-selected', 'true');

--- a/scripts/security.js
+++ b/scripts/security.js
@@ -1,5 +1,7 @@
 import { fetchCached } from './fetch-util.js';
 import { isUnifiedShellRuntimeAvailable, shell, user } from '../contenthub/unified-shell.js';
+import { getAdminConfig } from './site-config.js';
+import { getSecurityGroupMemberships } from './security-imslib.js';
 
 /**
  * @return {Promise<{imsOrgWithoutDomain: {string}, imsEnvironment: {string}, imsOrgID: {string}}|null>}
@@ -110,4 +112,10 @@ export async function checkUserAccess() {
       return true;
     }
   }
+}
+
+export async function checkAddAssetsAccess() {
+  const adminConfig = await getAdminConfig();
+  const securityGroupMemberships = await getSecurityGroupMemberships(await getBearerToken());
+  return securityGroupMemberships.some((grp) => grp.groupName === adminConfig.imsAuthorGroup);
 }


### PR DESCRIPTION
JIRA: [ASSETS-35859](https://jira.corp.adobe.com/browse/ASSETS-35859)

Added the ability to hide the 'Add Assets' button in the quick-links based by comparing the users IMS groups to the 'imsAuthorGroup' value in the 'admin-config.xlsx' file in sharepoint.

Test URLs:

Before: https://main--adobe-gmo--hlxsites.hlx.page/
After: https://assets-35859--adobe-gmo--hlxsites.hlx.page/
