### PR TITLE
ASSETS-88890 : Hide "Edit in Express" icon for Licensed Content

### DIFF
--- a/blocks/adp-asset-details-modal/adp-asset-details-modal.js
+++ b/blocks/adp-asset-details-modal/adp-asset-details-modal.js
@@ -9,7 +9,7 @@ import {
 import { closeModal } from '../../scripts/shared.js';
 import { authorizeURL, getAssetMetadata } from '../../scripts/polaris.js';
 import {
-  getAssetName, getAssetMimeType, getAssetTitle,
+  getAssetName, getAssetMimeType, getAssetTitle, isLicensedContent,
 } from '../../scripts/metadata.js';
 // eslint-disable-next-line import/no-cycle
 import { disableActionButtons } from '../adp-asset-details-panel/adp-asset-details-panel.js';
@@ -96,7 +96,8 @@ function createHeaderPanel(modal) {
   // ensure express button only shows for valid asset types
   const expressBtn = modal.querySelector('.action-edit-asset');
   const validCheck = fileValidity(format);
-  if (isCCEConfigured() && validCheck.isValid) {
+  if (isCCEConfigured() && validCheck.isValid && !isLicensedContent(assetJSON)) {
+    //Only show express button for content that is not licensed.
     expressBtn.classList.remove('hidden');
   } else if (!expressBtn.classList.contains('hidden')) {
     expressBtn.classList.add('hidden');

--- a/blocks/adp-asset-details-panel/adp-asset-details-panel.js
+++ b/blocks/adp-asset-details-panel/adp-asset-details-panel.js
@@ -6,7 +6,7 @@ import { openDownloadModal } from '../adp-download-modal/adp-download-modal.js';
 import { openAssetDetailsModal } from '../adp-asset-details-modal/adp-asset-details-modal.js';
 import { fetchMetadataAndCreateHTML } from '../../scripts/metadata-html-builder.js';
 import {
-  getAssetMimeType, getAssetTitle, getAssetName, getAssetHeight, getAssetWidth,
+  getAssetMimeType, getAssetTitle, getAssetName, getAssetHeight, getAssetWidth, isLicensedContent,
 } from '../../scripts/metadata.js';
 import {
   getAssetMetadata,
@@ -74,7 +74,8 @@ export async function openAssetDetailsPanel(assetId, resultsManagerObj) {
   // ensure express button only shows for valid asset types
   const expressBtn = assetDetailsPanel.querySelector('.action-edit-asset');
   const validCheck = fileValidity(fileFormat);
-  if (isCCEConfigured() && validCheck.isValid) {
+  if (isCCEConfigured() && validCheck.isValid && !isLicensedContent(assetJSON)) {
+    //Only show express button for content that is not licensed.
     expressBtn.classList.remove('hidden');
   } else if (!expressBtn.classList.contains('hidden')) {
     expressBtn.classList.add('hidden');

--- a/scripts/metadata.js
+++ b/scripts/metadata.js
@@ -181,6 +181,14 @@ export function getAssetSize(assetJSON) {
 }
 
 /**
+ * Is licensed content
+ * Returns true for gmo:licensedContent != 'no'
+ */
+export function isLicensedContent(assetJSON) {
+  return getMetadataValue('gmo:licensedContent', assetJSON) !== 'no';
+}
+
+/**
  * Predefined metadata fields that have special handling, can have compound values and a
  * special formatter.
  *


### PR DESCRIPTION
No Jira Ticket has been created for this task
Here is the Workfront Ticket
https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/task/65e91385006b5c560e697b94fb0cfd81/overview

For Content that is not licensed

Test URLs: Before
Not licensed content display Adobe Express button
https://main--adobe-gmo--hlxsites.hlx.page/assets#assetId=urn:aaid:aem:efa25f56-5906-40c4-a994-0b4e7eff504a

Test URLs: After
https://assets-88890--adobe-gmo--hlxsites.hlx.page/assets#assetId=urn:aaid:aem:efa25f56-5906-40c4-a994-0b4e7eff504a

The Adobe Express button is shown

<img width="1721" alt="Screenshot 2024-03-11 at 3 03 38 PM" src="https://github.com/hlxsites/adobe-gmo/assets/147942284/2acfc859-be44-4587-b43e-f0b806f52ecd">


For Content that is licensed

Test URLs : Before (The express button is shown)
https://main--adobe-gmo--hlxsites.hlx.page/assets#assetId=urn:aaid:aem:1a7925ac-7ca4-4cb3-958c-09e64e2ee9f1

Test URLs: After (The express button is not shown)
https://assets-88890--adobe-gmo--hlxsites.hlx.page/assets#assetId=urn:aaid:aem:1a7925ac-7ca4-4cb3-958c-09e64e2ee9f1


<img width="1717" alt="Screenshot 2024-03-11 at 3 01 04 PM" src="https://github.com/hlxsites/adobe-gmo/assets/147942284/7c05ef66-d24b-43dc-90c0-be353730d785">
