### PR TITLE
[Do Not Merge]]Revert code added for Collection API endpoints update

### DIFF
--- a/blocks/adp-collection-header/adp-collection-header.js
+++ b/blocks/adp-collection-header/adp-collection-header.js
@@ -62,7 +62,7 @@ function createCollectionInfoHeader(collectionInfoHeader, collection) {
         'Delete collection',
         `Are you sure you want to delete the collection "${collection.title}"?`,
         async () => {
-          await deleteCollection(collectionId, collection.title, collection.etag);
+          await deleteCollection(collectionId, collection.title);
           navigateTo(createLinkHref('/collections'));
         },
         'Proceed',

--- a/blocks/adp-infinite-results-collection/CollectionDatasource.js
+++ b/blocks/adp-infinite-results-collection/CollectionDatasource.js
@@ -88,8 +88,6 @@ export default class CollectionsDatasource {
         },
         removeItemFromMultiSelectionHandler: () => {
           infiniteResultsContainer.removeItemFromMultiSelection(assetId);
-          //Uncheck select all checkbox
-          document.getElementById('select-all-checkbox').checked = false;
         },
       },
     );

--- a/blocks/adp-infinite-results-collection/CollectionDatasource.js
+++ b/blocks/adp-infinite-results-collection/CollectionDatasource.js
@@ -88,6 +88,8 @@ export default class CollectionsDatasource {
         },
         removeItemFromMultiSelectionHandler: () => {
           infiniteResultsContainer.removeItemFromMultiSelection(assetId);
+          //Uncheck select all checkbox
+          document.getElementById('select-all-checkbox').checked = false;
         },
       },
     );

--- a/blocks/adp-infinite-results-collections/CollectionsDatasource.js
+++ b/blocks/adp-infinite-results-collections/CollectionsDatasource.js
@@ -2,29 +2,24 @@ import { createLinkHref, navigateTo } from '../../scripts/scripts.js';
 import {
   getCollectionID,
   getCollectionTitle,
-  searchListCollection,
+  listCollection,
 } from '../../scripts/collections.js';
 import { createCollectionCardElement } from '../../scripts/card-html-builder.js';
 
 export default class CollectionsDatasource {
+  cursor;
   infiniteResultsContainer = null;
 
   container = null;
 
   pageNumber = 0;
 
-  lastPage = false;
-
   async showMore() {
 
-    const list = await searchListCollection(5, this.pageNumber);
+    const list = await listCollection(5, this.cursor);
+    this.cursor = list.cursor;
 
     this.pageNumber += 1;
-
-    if (this.pageNumber >= list.nbPages){
-      this.lastPage = true;
-    }
-
     this.infiniteResultsContainer.resultsCallback(
       this.container,
       list.items,
@@ -37,14 +32,14 @@ export default class CollectionsDatasource {
   }
 
   isLastPage() {
-    return this.lastPage;
+    return !this.cursor;
   }
 
   async registerResultsCallback(container, infiniteResultsContainer) {
     this.infiniteResultsContainer = infiniteResultsContainer;
     this.container = container;
-
-    const list = await searchListCollection(5, this.pageNumber);
+    const list = await listCollection(5, this.cursor);
+    this.cursor = list.cursor;
 
     infiniteResultsContainer.resultsCallback(
       container,


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/) your PR is for, as well as a description of your changes:

**CODE REVERT**  added for below updates

1. Updated Collection API Endpoints to the ones in https://adobe-aem-assets-delivery-experimental.redoc.ly/#operation/getAllCollections
2. Updated following functions in collections.js : getCollection, createCollection, patchCollection, deleteCollection.
3. Replaced the function listCollection with searchListCollection which does not use the List All Collection API as that has not completed yet, instead the Search Collection API endpoint is used instead.
4. Updated adp-add-to-collection-modal.js that is used to create new collections, and add assets to a existing collection.
5. Updated adp-collection-header.js which is used to for the Collection Header.
6. Updated CollectionDatasource.js which is used to display the cards for all the existing Collections
7. Updated the file admin-config.xlsx and added the property searchCollectionIndex, which is used in the Search Collection API.

Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->
- Before: https://marketinghub.adobe.com/collection
- After: https://assets-88891--adobe-gmo--hlxsites.hlx.live/collection
