### PR TITLE
ASSETS-88892 : Fixed Collection Card List

### DIFF
--- a/blocks/adp-infinite-results-collections/CollectionsDatasource.js
+++ b/blocks/adp-infinite-results-collections/CollectionsDatasource.js
@@ -17,9 +17,8 @@ export default class CollectionsDatasource {
 
   async showMore() {
 
-    const list = await searchListCollection(5, this.pageNumber);
-
     this.pageNumber += 1;
+    const list = await searchListCollection(5, this.pageNumber);
 
     if (this.pageNumber >= list.nbPages){
       this.lastPage = true;


### PR DESCRIPTION
Fixed the Collections Container to show the correct number of Collections
the bug was showing some collections twice.

![Screenshot 2024-03-15 at 10 56 47 AM](https://github.com/hlxsites/adobe-gmo/assets/147942284/a0a3b723-5598-437c-af4b-bd9818a991c6)



Test URLs:
Before: https://main--adobe-gmo--hlxsites.hlx.page/qa/collections
After: https://assets-88892--adobe-gmo--hlxsites.hlx.page/qa/collections

