### PR TITLE
ASSETS-88896 : (Backend) Campaign Details: Collections

### DIFF
--- a/blocks/adp-infinite-results-campaign-collections/CollectionsDatasource.js
+++ b/blocks/adp-infinite-results-campaign-collections/CollectionsDatasource.js
@@ -20,7 +20,8 @@ export default class CollectionsDatasource {
 
     this.pageNumber += 1;
 
-    const list = await listCampaignCollections('gmo-campaignName:Everyone Can', '108396-1046543',pageNumber);
+    //Todo Pass in the campaignName
+    const list = await listCampaignCollections('gmo-campaignName:Everyone Can',pageNumber);
 
     if (this.pageNumber >= list.nbPages){
       this.lastPage = true;
@@ -45,7 +46,8 @@ export default class CollectionsDatasource {
     this.infiniteResultsContainer = infiniteResultsContainer;
     this.container = container;
 
-    const list = await listCampaignCollections('gmo-campaignName:Everyone Can', '108396-1046543',this.pageNumber);
+    //Todo Pass in the campaignName
+    const list = await listCampaignCollections('gmo-campaignName:Everyone Can',this.pageNumber);
 
     infiniteResultsContainer.resultsCallback(
       container,

--- a/blocks/adp-infinite-results-campaign-collections/CollectionsDatasource.js
+++ b/blocks/adp-infinite-results-campaign-collections/CollectionsDatasource.js
@@ -1,0 +1,88 @@
+import { createLinkHref, navigateTo } from '../../scripts/shared.js';
+import {
+  getCollectionID,
+  getCollectionTitle,
+  listCampaignCollections,
+} from '../../scripts/collections.js';
+
+import { createCollectionCardElement } from '../../scripts/card-html-builder.js';
+
+export default class CollectionsDatasource {
+  infiniteResultsContainer = null;
+
+  container = null;
+
+  pageNumber = 0;
+
+  lastPage = false;
+
+  async showMore() {
+
+    this.pageNumber += 1;
+
+    const list = await listCampaignCollections('gmo-campaignName:Everyone Can', '108396-1046543',pageNumber);
+
+    if (this.pageNumber >= list.nbPages){
+      this.lastPage = true;
+    }
+
+    this.infiniteResultsContainer.resultsCallback(
+      this.container,
+      list.items,
+      () => this.showMore(),
+      this.pageNumber,
+      false,
+      false,
+      () => this.isLastPage(),
+    );
+  }
+
+  isLastPage() {
+    return this.lastPage;
+  }
+
+  async registerResultsCallback(container, infiniteResultsContainer) {
+    this.infiniteResultsContainer = infiniteResultsContainer;
+    this.container = container;
+
+    const list = await listCampaignCollections('gmo-campaignName:Everyone Can', '108396-1046543',this.pageNumber);
+
+    infiniteResultsContainer.resultsCallback(
+      container,
+      list.items,
+      () => this.showMore(),
+      0,
+      true,
+      true,
+      () => this.isLastPage(),
+    );
+  }
+
+  getItemId(resultItem) {
+    return getCollectionID(resultItem);
+  }
+
+  getItemName(resultItem) {
+    return getCollectionTitle(resultItem);
+  }
+
+  createItemElement(item, infiniteResultsContainer) {
+    const id = getCollectionID(item);
+    const card = createCollectionCardElement(
+      item,
+      {
+        selectItemHandler: () => {
+          infiniteResultsContainer.toggleSelection(id);
+        },
+        deselectItemHandler: () => {
+          infiniteResultsContainer.deselectItem(id);
+        },
+      },
+    );
+    return card;
+  }
+
+  onItemSelected(itemElement, itemId) {
+    navigateTo(createLinkHref(`collection/${itemId}`));
+  }
+}

--- a/blocks/adp-infinite-results-campaign-collections/adp-infinite-results-campaign-collections.css
+++ b/blocks/adp-infinite-results-campaign-collections/adp-infinite-results-campaign-collections.css
@@ -1,0 +1,9 @@
+.adp-infinite-results-collections .metadata-fields .metadata-row {
+  grid-column: span 2;
+}
+
+.adp-infinite-results-collections .metadata-fields .label {
+    color: var(--metadata-label-color);
+    font: var(--metadata-label-font);
+    margin-bottom: 4px;
+}

--- a/blocks/adp-infinite-results-campaign-collections/adp-infinite-results-campaign-collections.js
+++ b/blocks/adp-infinite-results-campaign-collections/adp-infinite-results-campaign-collections.js
@@ -1,0 +1,9 @@
+import InfiniteResultsContainer from '../../scripts/infinite-results/InfiniteResultsContainer.js';
+// eslint-disable-next-line import/no-unresolved
+import CollectionsDatasource from './CollectionsDatasource.js';
+
+export default async function decorate(block) {
+  const instantSearchDatasource = new CollectionsDatasource();
+  const infiniteResultsContainer = new InfiniteResultsContainer(block, instantSearchDatasource);
+  infiniteResultsContainer.render();
+}

--- a/contenthub/hydration/hydration-utils.js
+++ b/contenthub/hydration/hydration-utils.js
@@ -145,6 +145,7 @@ export function getMetadataSchema(facetOptions){
             { name: 'Digital Editions', id: 'digital-editions' },
             { name: 'Dreamweaver', id: 'dreamweaver' },
             { name: 'Fill Sign', id: 'fill-sign' },
+            { name: 'Firefly', id: 'firefly' },
             { name: 'Frame.io', id: 'frame-io' },
             { name: 'Fresco', id: 'fresco' },
             { name: 'Http Dynamic Streaming', id: 'http-dynamic-streaming' },

--- a/scripts/collections.js
+++ b/scripts/collections.js
@@ -1,5 +1,6 @@
 import { getBearerToken } from './security.js';
 import {
+  getSearchIndex,
   getAssetHandlerApiKey,
   getDeliveryEnvironment,
   getBackendApiKey,
@@ -292,10 +293,12 @@ export async function searchListCollection(limit = undefined, page = 0) {
  * @returns {Promise<object>} A promise that resolves with a list of collections.
  * @throws {Error} If an HTTP error or network error occurs.
  */
-export async function listCampaignCollections(campaignName, indexName, page = 0) {
+export async function listCampaignCollections(campaignName, page = 0) {
 
   // Construct the query parameters
   const queryParams = new URLSearchParams();
+
+  const indexName = getSearchIndex();
 
   if (campaignName) {
     queryParams.append('campaignName', campaignName);


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/) your PR is for, as well as a description of your changes:

Workfront Task https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/task/65f1417f000707b860ef5b592bf483ac/overview

Test URLs:
https://assets-88896--adobe-gmo--hlxsites.hlx.page/drafts/tyrone/testpage

I created a test page in word document /drafts/tyrone/testpage.docx

https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B0CEA8450-1F62-4AD0-8474-80C6BE615A57%7D&file=testpage.docx&action=default&mobileredirect=true

Which uses the new block component `adp-infinite-results-campaign-collections`

The only thing that is hardcoded right now in the calling the new collections.js function listCampaignCollections(campaignName, page = 0) 

Which is called from  `blocks/adp-infinite-results-campaign-collections/CollectionsDatasource.js`
I hardcode the campaign name




<img width="1710" alt="Screenshot 2024-04-03 at 10 53 20 AM" src="https://github.com/hlxsites/adobe-gmo/assets/147942284/27bdd1f8-de2f-41d3-9292-d4091f1c54f2">

`    const list = await listCampaignCollections('gmo-campaignName:Everyone Can',pageNumber);`

The campaignName will be passed later in the page showing the Campaign Collections