### PR TITLE
Removed Prefix from Displayed UUID Value on Assets

### DIFF
--- a/scripts/metadata-html-builder.js
+++ b/scripts/metadata-html-builder.js
@@ -139,6 +139,12 @@ export async function fetchMetadataAndCreateHTML(metadataViewConfig, assetData, 
   if (assetData === undefined || assetJSON === undefined) {
     assetJSON = await getAssetMetadata(getAssetIdFromURL());
   }
+  // Remove "urn:aaid:aem:" prefix from displayed 'assetId' value
+  if (assetJSON.assetId) {
+    // A deep copy of the assetJSON object is created to avoid modifying the original object
+    assetJSON = JSON.parse(JSON.stringify(assetJSON));
+    assetJSON.assetId = assetJSON.assetId.replace('urn:aaid:aem:', '');
+  }
 
   const metadataContainer = document.createElement('div');
   metadataContainer.classList.add('metadata-container');


### PR DESCRIPTION
JIRA: [DXI-25955](https://jira.corp.adobe.com/browse/DXI-25955)

Made changes to the Metadata HTML Builder in order to remove the  "urn:aaid:aem:" prefix from the "assetId" displayed value in the assets detail side panel and modal without breaking other functionality dependent on "assetId". 

Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->
- Before: https://marketinghub.adobe.com/qa/assets
- After: https://dxi-25955-ch--adobe-gmo--hlxsites.hlx.page/qa/assets
