### PR TITLE
make links configurable, remove extraneous logs

### DIFF
--- a/blocks/gmo-campaign-details/gmo-campaign-details.js
+++ b/blocks/gmo-campaign-details/gmo-campaign-details.js
@@ -1,13 +1,14 @@
-import { decorateIcons } from '../../scripts/lib-franklin.js';
+import { decorateIcons, readBlockConfig } from '../../scripts/lib-franklin.js';
 import { getQueryVariable } from '../../scripts/shared.js';
 import { getProgramInfo } from '../../scripts/graphql.js';
 import { checkBlankString } from '../gmo-campaign-list/gmo-campaign-list.js'
 import { statusMappings, productMappings } from '../../scripts/shared-campaigns.js';
 import { getBaseConfigPath } from '../../scripts/site-config.js';
 
+let blockConfig;
+
 export default async function decorate(block) {
     const programName = getQueryVariable('programName');
-    //const programData = await getProgramDetails(programName);
     const programData = await getProgramInfo(programName, "program");
     const deliverables = getProgramInfo(programName, "deliverables");
     const program = programData.data.programList.items[0];
@@ -16,6 +17,7 @@ export default async function decorate(block) {
     const audiences = buildAudienceList(program).outerHTML;
     const date = formatDate(program.launchDate);
     const status = buildStatus(program.status).outerHTML;
+    blockConfig = readBlockConfig(block);
     block.innerHTML = `
     <div class="back-button">
         <span class="icon icon-back"></span>
@@ -164,7 +166,8 @@ export default async function decorate(block) {
     })
     block.querySelector('.back-button').addEventListener('click', () => {
         const host = location.origin + getBaseConfigPath();
-        document.location.href = host + `/campaigns`;
+        const listPage = blockConfig.listpage;
+        document.location.href = host + `/${listPage}`;
     })
     block.querySelectorAll('.read-more').forEach((button) => {
         button.addEventListener('click', (event) => {
@@ -430,7 +433,6 @@ function buildTableRow(deliverableJson, kpi, createHidden) {
         <div class='property table-column column8'>${checkBlankString(deliverableJson.taskCompletionDate)}</div>
         <div class='property table-column column9'>${checkBlankString(deliverableJson.driver)}</div>
     `
-    console.log(deliverableJson.linkedFolderLink);
     if (!(deliverableJson.linkedFolderLink == null)) {
         const finalAssetLink = document.createElement('a');
         finalAssetLink.href = deliverableJson.linkedFolderLink;

--- a/blocks/gmo-campaign-list/gmo-campaign-list.js
+++ b/blocks/gmo-campaign-list/gmo-campaign-list.js
@@ -39,6 +39,7 @@ let currentPage = 1;
 let currentNumberPerPage = 4;
 //Get Campaign Count for pagination
 let campaignCount = await graphqlCampaignCount();
+let blockConfig;
 
 //Custom event gmoCampaignListBlock to allow the gmo-campaign-header to trigger the gmo-campaign-list to update
 document.addEventListener('gmoCampaignListBlock', async function() {
@@ -64,7 +65,7 @@ document.addEventListener('gmoCampaignListBlock', async function() {
 
 
 export default async function decorate(block, numPerPage = currentNumberPerPage, cursor = '', previousPage = false, nextPage = false, graphQLFilter = {}) {
-
+    blockConfig = readBlockConfig(block);
     const campaignPaginatedResponse = await graphqlAllCampaignsFilter(numPerPage, cursor,graphQLFilter);
     const campaigns = campaignPaginatedResponse.data.programPaginated.edges;
     currentPageInfo = campaignPaginatedResponse.data.programPaginated.pageInfo;
@@ -147,7 +148,7 @@ function buildCampaignList(campaigns, numPerPage) {
     listWrapper.classList.add('list-items');
     listWrapper.dataset.totalresults = campaigns.length;
     const host = location.origin + getBaseConfigPath();
-    
+    const detailsPage = blockConfig.detailspage;
     campaigns.forEach((campaign, index) => {
         const campaignRow = document.createElement('div');
         campaignRow.classList.add('campaign-row');
@@ -155,8 +156,7 @@ function buildCampaignList(campaigns, numPerPage) {
         const campaignInfoWrapper = document.createElement('div');
         campaignInfoWrapper.classList.add('campaign-info-wrapper','column-1');
         const campaignIconLink = document.createElement('a');
-        campaignIconLink.href = host + `/campaign-details?programName=${campaign.node.programName}`
-        
+        campaignIconLink.href = host + `/${detailsPage}?programName=${campaign.node.programName}`
         const campaignIcon = document.createElement('div');
         campaignIcon.classList.add('campaign-icon');
         campaignIcon.dataset.programname = campaign.node.programName;
@@ -213,9 +213,7 @@ function buildProductsList(productList) {
 
 function buildProduct(product) {
     const productEl = document.createElement('div');
-    //let productIcon = product;
     if (product == null) product = 'Not Available';
-    //if (product == 'Not Available') productIcon = "gear";
     const productLabel = productMappings[product].name;
     const productIcon = productMappings[product].icon;
 
@@ -450,21 +448,6 @@ function sortColumn(dir, property) {
     });
 }
 
-/*
-function determineStatusColor(status) {
-    switch(status) {
-        case 'Current':
-            return 'green';
-        case 'Delayed':
-            return 'yellow';
-        case 'Canceled':
-            return 'red';
-        default:
-            return 'red';       
-    }
-}
-*/
-
 // supply dummy data if none present
 export function checkBlankString(string) {
     if (string == undefined || string == '' ) {
@@ -473,8 +456,3 @@ export function checkBlankString(string) {
         return string;
     }
 }
-
-function openCampaignDetails(campaignName) {
-    document.location.href = `/campaign-details?campaignName=${campaignName}`;
-}
-    


### PR DESCRIPTION
Make links to/from the list and details blocks configurable.

On the `gmo-campaign-list` block document, add a property called `detailsPage` and supply the name of the document that has the `gmo-campaign-details` block.
Similarly, on the `gmo-campaign-details` block document, add a property called `listPage` and give the name of the document with the `gmo-campaign-list` block.

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-98995--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/campaigns
