### PR TITLE
Added getBaseConfigPath to Collections Back Button

### DIFF
--- a/blocks/adp-collection-header/adp-collection-header.js
+++ b/blocks/adp-collection-header/adp-collection-header.js
@@ -2,6 +2,7 @@ import { getCollection, getCollectionIdFromURL, deleteCollection } from '../../s
 import createConfirmDialog from '../../scripts/confirm-dialog.js';
 import { decorateIcons } from '../../scripts/lib-franklin.js';
 import { createLinkHref, navigateTo } from '../../scripts/shared.js';
+import { getBaseConfigPath } from '../../scripts/site-config.js';
 
 import {
   selectAllAssets, deselectAllAssets,
@@ -13,7 +14,7 @@ function createCollectionInfoHeader(collectionInfoHeader, collection) {
   collectionInfoHeader.innerHTML = `
         <div class="adp-collection-header-left">
           <div class="back-button">
-              <a href="/collections"><span class="icon icon-back"></span></a>
+              <a href="${getBaseConfigPath()}/collections"><span class="icon icon-back"></span></a>
           </div>
           <div class="adp-collection-header-collection-info">
             <div class="adp-collection-title"></div>


### PR DESCRIPTION
JIRA: [DXI-26385](https://jira.corp.adobe.com/browse/DXI-26385)

This change will make sure that users in the QA environment will be sent to the proper environment when using the back button in the collections header.

Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->
- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-39177--adobe-gmo--hlxsites.hlx.page/assets
