### PR TITLE
platforms mapping with graphql

### DIFF
--- a/scripts/shared-mappings.js
+++ b/scripts/shared-mappings.js
@@ -14,46 +14,6 @@ export function filterArray(array, key, value) {
     const arrayMatch = array.filter(match => match[key] === value);
     return arrayMatch.length > 0 ? arrayMatch : null;
 }
-/*
-async function buildProduct(product) {
-    const configPath = getBaseConfigPath();
-    const defaultIcon = configPath + '/logo/products/default-app-icon.svg';
-    const iconMapping = await getProductIconMapping();
-    const iconMatch = filterArray(iconMapping, 'Product-offering', product);
-    const icon = iconMatch ? configPath + iconMatch[0]['Icon-path'] : defaultIcon;
-
-    const nameMapping = await resolveMappings("getProductList");
-    const nameMatch = filterArray(nameMapping, 'value', product);
-    const productName = nameMatch ? nameMatch[0].text : product;
-
-    const productEl = document.createElement('div');
-    productEl.classList.add('product-entry');
-    productEl.innerHTML = `
-        <img class='icon' src=${icon}></img>
-        <span class='product-label'>${productName}</span>
-    `;
-
-    return productEl;
-}
-async function buildProductList(program) {
-    const configPath = getBaseConfigPath();
-    const defaultIcon = configPath + '/logo/products/default-app-icon.svg';
-    const iconMapping = await getProductIconMapping();
-    const iconMatch = filterArray(iconMapping, 'Product-offering', product);
-    const icon = iconMatch ? configPath + iconMatch[0]['Icon-path'] : defaultIcon;
-
-    const productsMatch = filterArray(await resolveMappings("getProductList"), 'value', product);
-    const productsText = productsMatch ? productsMatch[0].text : product;
-
-    const productList = document.createElement('div');
-    productList.classList.add('product', 'card-content');
-    productList.innerHTML = `
-        <img class="icon" src=${icon}></img>
-        ${productsText}
-    `
-    document.querySelector('.card.products').appendChild(productList);
-}
-*/
 
 export async function getProductMapping(product) {
     const configPath = getBaseConfigPath();


### PR DESCRIPTION
Add graphql label mapping for 'platform' property on the campaign list and campaign details blocks.

Also cleaned up commented-out code from previous PR.

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-98997--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/campaign-details?programName=4/23%20Release:%20MAX%20London%20Ps%20+%20Id
