### PR TITLE
ASSETS-88908 : Remove Console Error in Marketing Dashboard page  and Campaign Details when no image is found

### DIFF
--- a/blocks/gmo-campaign-details/gmo-campaign-details.js
+++ b/blocks/gmo-campaign-details/gmo-campaign-details.js
@@ -189,8 +189,10 @@ export default async function decorate(block) {
     buildProductCard(program);
     try {
         const imageObject = await searchAsset(program.programName, program.campaignName);
-        insertImageIntoCampaignImg(block,imageObject);
-        document.getElementById('totalassets').textContent = imageObject.assetCount;
+        if (imageObject){
+          insertImageIntoCampaignImg(block,imageObject);
+          document.getElementById('totalassets').textContent = imageObject.assetCount;
+        }
     } catch (error) {
         console.error("Failed to load campaign image:", error);
     }

--- a/blocks/gmo-campaign-list/gmo-campaign-list.js
+++ b/blocks/gmo-campaign-list/gmo-campaign-list.js
@@ -179,7 +179,6 @@ async function buildCampaignList(campaigns, numPerPage) {
             iconImage.src = imageObject.imageUrl;
             iconImage.alt = imageObject.imageAltText;
         } catch (error) {
-            console.error("No campaign image found:", error);
         }
         // Append the image to the campaignIcon div
         campaignIcon.appendChild(iconImage);

--- a/scripts/assets.js
+++ b/scripts/assets.js
@@ -88,9 +88,16 @@ export async function searchAsset(programName, campaignName, imageWidth = 80) {
       // Asset retrieved successfully
       const responseBody = await response.json();
       const assetData = responseBody.results[0].hits[0];
-      const totalAssets = responseBody.results[0].nbHits;
-      const thumbnailURL = await getOptimizedDeliveryUrl(assetData.assetId, assetData['repo-name'], imageWidth);
-      return {imageUrl : thumbnailURL, imageAltText: assetData['repo-name'], assetCount: totalAssets};
+      if (assetData)
+      {
+        const totalAssets = responseBody.results[0].nbHits;
+        const thumbnailURL = await getOptimizedDeliveryUrl(assetData.assetId, assetData['repo-name'], imageWidth);
+        return {imageUrl : thumbnailURL, imageAltText: assetData['repo-name'], assetCount: totalAssets};
+      }
+      else
+      {
+        return null;
+      }
     }
     // Handle other response codes
     throw new Error(`Failed to search asset: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/task/6656256a002ca293fd06b120b67f2beb/overview


Test URLs:
https://assets-88908--adobe-gmo--hlxsites.hlx.page/qa/marketing-dashboard#

Screen Shot of No Console Error messages 
<img width="1743" alt="Screenshot 2024-05-28 at 4 21 11 PM" src="https://github.com/hlxsites/adobe-gmo/assets/147942284/29351b21-27b5-4105-8f68-dae0b22f4857">

Screenshot of Campaign Detail when Image is not found, showing no console errors

<img width="1637" alt="Screenshot 2024-05-28 at 4 45 26 PM" src="https://github.com/hlxsites/adobe-gmo/assets/147942284/42221258-bafc-4e18-bfd7-060711592d64">


