### PR TITLE
add programID parameter to deliverable query

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -7,7 +7,7 @@ import { searchAsset } from '../../scripts/assets.js';
 
 let blockConfig;
 const programName = getQueryVariable('programName');
-const programRefNumber = getQueryVariable('programReferenceNumber');
+const programID = getQueryVariable('programID');
 const deliverableMappings = resolveMappings("getDeliverableTypeMapping");
 const platformMappings = resolveMappings("getPlatformsMapping");
 
@@ -15,9 +15,9 @@ export default async function decorate(block) {
 
     const encodedSemi = encodeURIComponent(';');
     const encodedProgram = encodeURIComponent(programName);
-    const programQueryString = `getProgramDetails${encodedSemi}programName=${encodedProgram}${encodedSemi}programReferenceNumber=${encodeURIComponent(programRefNumber)}`;
+    const programQueryString = `getProgramDetails${encodedSemi}programName=${encodedProgram}${encodedSemi}programID=${encodeURIComponent(programID)}`;
     const programData = await executeQuery(programQueryString);
-    const deliverableQueryString = `getProgramDeliverables${encodedSemi}programName=${encodedProgram}`;
+    const deliverableQueryString = `getProgramDeliverables${encodedSemi}programName=${encodedProgram}${encodedSemi}programID=${encodeURIComponent(programID)}`;
     const deliverables = await executeQuery(deliverableQueryString);
 
     const p0TargetMarketArea = programData.data.programList.items[0].p0TargetMarketArea;

--- a/blocks/gmo-program-list/gmo-program-list.js
+++ b/blocks/gmo-program-list/gmo-program-list.js
@@ -148,6 +148,7 @@ async function buildCampaignList(campaigns, numPerPage) {
     const detailsPage = blockConfig.detailspage;
 
     for (const campaign of campaigns) {
+        console.log(campaign);
         const index = campaigns.indexOf(campaign);
         const campaignRow = document.createElement('div');
         const programName = campaign.node.programName;
@@ -225,9 +226,18 @@ function buildStatus(statusWrapper, campaign) {
     const statusStr = checkBlankString(campaign.node.status);
     const statusArray = statusMapping.data.jsonByPath.item.json.options;
     const statusMatch = statusArray.filter(item => item.value === statusStr);
-    const statusText = statusMatch.length > 0 ? statusMatch[0].text : statusStr;
+
+    let statusText, statusColor;
+    if (statusMatch.length > 0) {
+        statusText = statusMatch[0].text;
+        statusColor = statusMatch[0]["color-code"];
+    } else {
+        statusText = statusStr;
+        statusColor = "BABABA";
+    }
+
     campaignStatus.textContent = statusText;
-    campaignStatus.style.backgroundColor = "#" + statusMatch[0]["color-code"];
+    campaignStatus.style.backgroundColor = "#" + statusColor;
     campaignStatus.classList.add('status');
     campaignStatus.dataset.property = 'status';
     statusWrapper.appendChild(campaignStatus);

--- a/blocks/gmo-program-list/gmo-program-list.js
+++ b/blocks/gmo-program-list/gmo-program-list.js
@@ -152,7 +152,7 @@ async function buildCampaignList(campaigns, numPerPage) {
         const campaignRow = document.createElement('div');
         const programName = campaign.node.programName;
         const campaignName = campaign.node.campaignName;
-        const programRef = campaign.node.programReferenceNumber;
+        const programID = campaign.node.programID ? campaign.node.programID : "";
 
         campaignRow.classList.add('campaign-row');
         if ((index + 1) > numPerPage) campaignRow.classList.add('hidden');
@@ -161,15 +161,15 @@ async function buildCampaignList(campaigns, numPerPage) {
         campaignInfoWrapper.classList.add('campaign-info-wrapper', 'column-1');
 
         const campaignIconLink = document.createElement('a');
-        let campaignDetailsLink = host + `/${detailsPage}?programName=${campaign.node.programName}&`;
-        campaignDetailsLink += `programReferenceNumber=${campaign.node.programReferenceNumber ? campaign.node.programReferenceNumber : ""}`
+        let campaignDetailsLink = host + `/${detailsPage}?programName=${programName}&`;
+        campaignDetailsLink += `programID=${programID}`
         campaignIconLink.href = campaignDetailsLink;
 
         const campaignIcon = document.createElement('div');
         campaignIcon.classList.add('campaign-icon');
         campaignIcon.dataset.programname = programName;
         campaignIcon.dataset.campaignname = campaignName;
-        campaignIcon.dataset.reference = programRef;
+        campaignIcon.dataset.programid = programID;
         addThumbnail(campaignIcon, programName, campaignName);
         campaignIconLink.appendChild(campaignIcon);
         const campaignNameWrapper = document.createElement('div');

--- a/blocks/gmo-program-list/gmo-program-list.js
+++ b/blocks/gmo-program-list/gmo-program-list.js
@@ -148,7 +148,6 @@ async function buildCampaignList(campaigns, numPerPage) {
     const detailsPage = blockConfig.detailspage;
 
     for (const campaign of campaigns) {
-        console.log(campaign);
         const index = campaigns.indexOf(campaign);
         const campaignRow = document.createElement('div');
         const programName = campaign.node.programName;


### PR DESCRIPTION
Update queries to use 'programID' instead of 'programReferenceNumber'.

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-98993--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/program-details?programName=FY24%20Q1_Feature%20Marketing&programID=6568e63001f3b37dc342a6c17cda32c3
