### PR TITLE
Make content fragment path for WF mappings configurable

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -2,23 +2,15 @@ import { decorateIcons, readBlockConfig } from '../../scripts/lib-franklin.js';
 import { getQueryVariable } from '../../scripts/shared.js';
 import { executeQuery } from '../../scripts/graphql.js';
 //import { resolveMappings, filterArray, getProductMapping, checkBlankString, dateFormat, statusMapping } from '../../scripts/shared-program.js';
-import { filterArray, getProductMapping, checkBlankString, dateFormat, statusMapping } from '../../scripts/shared-program.js';
+import { filterArray, getProductMapping, checkBlankString, dateFormat, statusMapping, getMappingArray } from '../../scripts/shared-program.js';
 import { getBaseConfigPath } from '../../scripts/site-config.js';
 import { searchAsset } from '../../scripts/assets.js';
 
 let blockConfig;
 const programName = getQueryVariable('programName');
 const programID = getQueryVariable('programID');
-const deliverableCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/deliverableType';
-const platformCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/platform';
-//const deliverableMappings = resolveMappings("getDeliverableTypeMapping");
-const deliverableMappings = executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(deliverableCf)}`).then((response) => {
-    return response.data.jsonByPath.item.json.options;
-})
-//const platformMappings = resolveMappings("getPlatformsMapping");
-const platformMappings = executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(platformCf)}`).then((response) => {
-    return response.data.jsonByPath.item.json.options;
-})
+const deliverableMappings = getMappingArray('deliverableType');
+const platformMappings = getMappingArray('platforms');
 
 export default async function decorate(block) {
 
@@ -342,9 +334,7 @@ function buildArtifactLinks(program) {
 async function buildStatus(status) {
     const statusDiv = document.createElement('div');
     statusDiv.classList.add('campaign-status');
-    //const statusArray = await resolveMappings("getStatusList");
-    const statusArray = statusMapping.data.jsonByPath.item.json.options;
-    const statusMatch = filterArray(statusArray, 'value', status);
+    const statusMatch = filterArray(statusMapping, 'value', status);
     const statusText = statusMatch ? statusMatch[0].text : status;
     const statusHex = statusMatch[0]["color-code"];
     statusDiv.textContent = statusText;

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -1,7 +1,6 @@
 import { decorateIcons, readBlockConfig } from '../../scripts/lib-franklin.js';
 import { getQueryVariable } from '../../scripts/shared.js';
 import { executeQuery } from '../../scripts/graphql.js';
-//import { resolveMappings, filterArray, getProductMapping, checkBlankString, dateFormat, statusMapping } from '../../scripts/shared-program.js';
 import { filterArray, getProductMapping, checkBlankString, dateFormat, statusMapping, getMappingArray } from '../../scripts/shared-program.js';
 import { getBaseConfigPath } from '../../scripts/site-config.js';
 import { searchAsset } from '../../scripts/assets.js';

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -1,15 +1,24 @@
 import { decorateIcons, readBlockConfig } from '../../scripts/lib-franklin.js';
 import { getQueryVariable } from '../../scripts/shared.js';
 import { executeQuery } from '../../scripts/graphql.js';
-import { resolveMappings, filterArray, getProductMapping, checkBlankString, dateFormat } from '../../scripts/shared-program.js';
+//import { resolveMappings, filterArray, getProductMapping, checkBlankString, dateFormat, statusMapping } from '../../scripts/shared-program.js';
+import { filterArray, getProductMapping, checkBlankString, dateFormat, statusMapping } from '../../scripts/shared-program.js';
 import { getBaseConfigPath } from '../../scripts/site-config.js';
 import { searchAsset } from '../../scripts/assets.js';
 
 let blockConfig;
 const programName = getQueryVariable('programName');
 const programID = getQueryVariable('programID');
-const deliverableMappings = resolveMappings("getDeliverableTypeMapping");
-const platformMappings = resolveMappings("getPlatformsMapping");
+const deliverableCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/deliverableType';
+const platformCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/platform';
+//const deliverableMappings = resolveMappings("getDeliverableTypeMapping");
+const deliverableMappings = executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(deliverableCf)}`).then((response) => {
+    return response.data.jsonByPath.item.json.options;
+})
+//const platformMappings = resolveMappings("getPlatformsMapping");
+const platformMappings = executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(platformCf)}`).then((response) => {
+    return response.data.jsonByPath.item.json.options;
+})
 
 export default async function decorate(block) {
 
@@ -333,7 +342,8 @@ function buildArtifactLinks(program) {
 async function buildStatus(status) {
     const statusDiv = document.createElement('div');
     statusDiv.classList.add('campaign-status');
-    const statusArray = await resolveMappings("getStatusList");
+    //const statusArray = await resolveMappings("getStatusList");
+    const statusArray = statusMapping.data.jsonByPath.item.json.options;
     const statusMatch = filterArray(statusArray, 'value', status);
     const statusText = statusMatch ? statusMatch[0].text : status;
     const statusHex = statusMatch[0]["color-code"];

--- a/blocks/gmo-program-header/gmo-program-header.js
+++ b/blocks/gmo-program-header/gmo-program-header.js
@@ -191,8 +191,7 @@ function populateDropdown(response, dropdownId, type) {
 
 // Function to filter products based on selected business line
 function filterProductsByBusinessLine(businessLine) {
-    const products = productList.data.jsonByPath.item.json.options;
-    const filteredProducts = products.filter(product =>
+    const filteredProducts = productList.filter(product =>
         product['business-line'].includes(businessLine)
     );
     populateDropdown(filteredProducts, 'dropdownProductOptions', 'productOffering');

--- a/blocks/gmo-program-header/gmo-program-header.js
+++ b/blocks/gmo-program-header/gmo-program-header.js
@@ -1,6 +1,6 @@
 import { decorateIcons } from '../../scripts/lib-franklin.js';
-import { graphqlQueryNameList, graphqlCampaignByName, executeQuery } from '../../scripts/graphql.js';
-import { statusMapping, productList } from '../../scripts/shared-program.js';
+import { graphqlCampaignByName } from '../../scripts/graphql.js';
+import { statusMapping, productList, getMappingArray } from '../../scripts/shared-program.js';
 
 export default async function decorate(block) {
     block.innerHTML = `
@@ -132,30 +132,14 @@ export default async function decorate(block) {
 
 async function initializeDropdowns() {
     // Business Line List
-
-    //change mapping here
-    const businessCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/lineofBusiness';
-    executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(businessCf)}`).then((response) => {
+    getMappingArray('businessLine').then((response) => {
         populateDropdown(response, 'dropdownBusinessOptions', 'businessLine');
     })
-    /*
-    graphqlQueryNameList('getBusinessLine').then((response) => {
-        populateDropdown(response, 'dropdownBusinessOptions', 'businessLine');
-    });
-    */
 
     // Geo List
-
-    //change mapping here
-    const geoCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/p1TargetMarketGeo';
-    executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(geoCf)}`).then((response) => {
-        populateDropdown(response, 'dropdownBusinessOptions', 'businessLine');
-    })
-    /*
-    graphqlQueryNameList('getGeoList').then((response) => {
+    getMappingArray('geoList').then((response) => {
         populateDropdown(response, 'dropdownGeoOptions', 'p0TargetGeo');
-    });
-    */
+    })
 
     // Status List
     const statusResponse = await statusMapping;

--- a/blocks/gmo-program-header/gmo-program-header.js
+++ b/blocks/gmo-program-header/gmo-program-header.js
@@ -134,12 +134,12 @@ async function initializeDropdowns() {
     // Business Line List
     getMappingArray('businessLine').then((response) => {
         populateDropdown(response, 'dropdownBusinessOptions', 'businessLine');
-    })
+    });
 
     // Geo List
     getMappingArray('geoList').then((response) => {
         populateDropdown(response, 'dropdownGeoOptions', 'p0TargetGeo');
-    })
+    });
 
     // Status List
     const statusResponse = await statusMapping;

--- a/blocks/gmo-program-header/gmo-program-header.js
+++ b/blocks/gmo-program-header/gmo-program-header.js
@@ -1,5 +1,5 @@
 import { decorateIcons } from '../../scripts/lib-franklin.js';
-import { graphqlQueryNameList, graphqlCampaignByName } from '../../scripts/graphql.js';
+import { graphqlQueryNameList, graphqlCampaignByName, executeQuery } from '../../scripts/graphql.js';
 import { statusMapping, productList } from '../../scripts/shared-program.js';
 
 export default async function decorate(block) {
@@ -132,14 +132,30 @@ export default async function decorate(block) {
 
 async function initializeDropdowns() {
     // Business Line List
+
+    //change mapping here
+    const businessCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/lineofBusiness';
+    executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(businessCf)}`).then((response) => {
+        populateDropdown(response, 'dropdownBusinessOptions', 'businessLine');
+    })
+    /*
     graphqlQueryNameList('getBusinessLine').then((response) => {
         populateDropdown(response, 'dropdownBusinessOptions', 'businessLine');
     });
+    */
 
     // Geo List
+
+    //change mapping here
+    const geoCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/p1TargetMarketGeo';
+    executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(geoCf)}`).then((response) => {
+        populateDropdown(response, 'dropdownBusinessOptions', 'businessLine');
+    })
+    /*
     graphqlQueryNameList('getGeoList').then((response) => {
         populateDropdown(response, 'dropdownGeoOptions', 'p0TargetGeo');
     });
+    */
 
     // Status List
     const statusResponse = await statusMapping;

--- a/blocks/gmo-program-list/gmo-program-list.js
+++ b/blocks/gmo-program-list/gmo-program-list.js
@@ -228,8 +228,7 @@ async function buildCampaignList(campaigns, numPerPage) {
 function buildStatus(statusWrapper, campaign) {
     const campaignStatus = document.createElement('div');
     const statusStr = checkBlankString(campaign.node.status);
-    const statusArray = statusMapping.data.jsonByPath.item.json.options;
-    const statusMatch = statusArray.filter(item => item.value === statusStr);
+    const statusMatch = statusMapping.filter(item => item.value === statusStr);
 
     let statusText, statusColor;
     if (statusMatch.length > 0) {

--- a/scripts/graphql.js
+++ b/scripts/graphql.js
@@ -5,6 +5,7 @@ import { logError } from './scripts.js';
 const baseApiUrl = `${await getGraphqlEndpoint()}/graphql/execute.json`;
 const projectId = 'gmo';
 
+/*
 export async function graphqlQueryNameList(queryNameList) {
   const queryName = queryNameList;
   //persisted query URLs have to be encoded together with the first semicolon
@@ -29,6 +30,7 @@ export async function graphqlQueryNameList(queryNameList) {
       throw error; // Rethrow or handle error as appropriate
   });
 }
+*/
 
 export async function graphqlCampaignCount(filter = {}) {
   const queryName = 'getTotalPrograms';
@@ -214,3 +216,9 @@ export async function executeQuery(queryString) {
       throw error; // Rethrow or handle error as appropriate
   });
 };
+
+export async function getMapping(mappingPath) {
+
+
+
+}

--- a/scripts/graphql.js
+++ b/scripts/graphql.js
@@ -5,33 +5,6 @@ import { logError } from './scripts.js';
 const baseApiUrl = `${await getGraphqlEndpoint()}/graphql/execute.json`;
 const projectId = 'gmo';
 
-/*
-export async function graphqlQueryNameList(queryNameList) {
-  const queryName = queryNameList;
-  //persisted query URLs have to be encoded together with the first semicolon
-  const graphqlEndpoint = `${baseApiUrl}/${projectId}/${queryName}`;
-  const jwtToken = await getBearerToken();
-
-  // Return the fetch promise chain so that it can be awaited outside
-  return fetch(graphqlEndpoint, {
-      method: 'GET',
-      headers: {
-          Authorization: jwtToken,
-      },
-  }).then(response => {
-      if (!response.ok) {
-          throw new Error(`HTTP error! Status: ${response.status}`);
-      }
-      return response.json();
-  }).then(data => {
-      return data; // Make sure to return the data so that the promise resolves with it
-  }).catch(error => {
-      console.error('Error fetching data: ', error);
-      throw error; // Rethrow or handle error as appropriate
-  });
-}
-*/
-
 export async function graphqlCampaignCount(filter = {}) {
   const queryName = 'getTotalPrograms';
   const encodedSemiColon = encodeURIComponent(';');
@@ -216,9 +189,3 @@ export async function executeQuery(queryString) {
       throw error; // Rethrow or handle error as appropriate
   });
 };
-
-export async function getMapping(mappingPath) {
-
-
-
-}

--- a/scripts/shared-program.js
+++ b/scripts/shared-program.js
@@ -1,4 +1,3 @@
-//import { executeQuery, graphqlQueryNameList } from "./graphql.js";
 import { executeQuery } from "./graphql.js";
 import { getProductIconMapping, getBaseConfigPath, getQueryPaths } from './site-config.js';
 

--- a/scripts/shared-program.js
+++ b/scripts/shared-program.js
@@ -1,18 +1,24 @@
-import { graphqlQueryNameList } from "./graphql.js";
+//import { executeQuery, graphqlQueryNameList } from "./graphql.js";
+import { executeQuery } from "./graphql.js";
 import { getProductIconMapping, getBaseConfigPath } from './site-config.js';
 
 let iconMapping;
-export let statusMapping = await graphqlQueryNameList('getStatusList');
-export let productList = await graphqlQueryNameList('getProductList');
+//export let statusMapping = await graphqlQueryNameList('getStatusList');
+const statusCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/status';
+const productCf = '/content/dam/gmo-cf/en/wf-picklist-data-source/product'
+export let statusMapping = await executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(statusCf)}`)
+export let productList = await executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(productCf)}`)
 
 /*
 *   Executes graphql query for 'friendly' labels and returns array of the results
 */
+/*
 export async function resolveMappings(mappingType) {
     const response = await graphqlQueryNameList(mappingType);
     const mappingArray = response.data.jsonByPath.item.json.options;
     return mappingArray;
 }
+*/
 
 /**
  * Filter provided array based on provided key/value pair
@@ -32,7 +38,8 @@ export async function getProductMapping(product) {
     } 
     const icon = iconMatch ? configPath + iconMatch[0]['Icon-path'] : defaultIcon;
 
-    if (productList == undefined) productList = await graphqlQueryNameList('getProductList');
+    //if (productList == undefined) productList = await graphqlQueryNameList('getProductList');
+    if (productList == undefined) productList = await executeQuery(`getMappings${encodeURIComponent(';')}path=${encodeURIComponent(productCf)}`)
     const productsArray = productList.data.jsonByPath.item.json.options;
     const productsMatch = filterArray(productsArray, 'value', product);
     const productsText = productsMatch ? productsMatch[0].text : product;

--- a/scripts/site-config.js
+++ b/scripts/site-config.js
@@ -380,3 +380,18 @@ export async function getProductIconMapping() {
   }
   return iconArray;
 }
+
+/**
+ * @returns {Array} with mapping-type and the path to its content fragment.
+ */
+export async function getQueryPaths() {
+  let mapping = [];
+  const response = await getConfig('site-config.json');
+  for (const entry of response['query-fragments'].data || []) {
+    mapping.push({
+      type: entry['mapping-Type'],
+      path: entry['path']
+    });
+  }
+  return mapping;
+}


### PR DESCRIPTION
Allow authors to provide mappings for the paths to content fragments that we use to derive friendly labels for Workfront values.

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-98991--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/programs
