### PR TITLE
ASSETS-88917: [Issue] 404 Error on Getting Total Asset Count

### DIFF
--- a/scripts/polaris.js
+++ b/scripts/polaris.js
@@ -101,13 +101,10 @@ export async function authorizeURL(url) {
 
   const response = await fetch(url, options);
 
+
   if (!response.ok) {
-    // Handle specific HTTP errors
-    if (response.status === 404) {
-      throw new Error('Not Found (404)');
-    } else {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
+    // Return the full URL to the asset icon if the response is not OK, as the asset was not found
+    return new URL('/icons/asset.svg', window.location.origin).href;
   }
 
   const imageBlob = await response.blob();


### PR DESCRIPTION
Replaced throwing 404 error when the asset is not found, with asset icon

https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/task/6668691100211267b48729347cc39bd9/overview

Test URLs:

Before
https://rc--adobe-gmo--hlxsites.hlx.page/program-details?programName=Acrobat%27s%20Got%20It&programID=6578983c049d6162a756ac83e90f3ccb

After

https://assets-88917--adobe-gmo--hlxsites.hlx.page/program-details?programName=Acrobat%27s%20Got%20It&programID=6578983c049d6162a756ac83e90f3ccb
https://assets-88917


<img width="1899" alt="Screenshot 2024-06-11 at 4 18 35 PM" src="https://github.com/hlxsites/adobe-gmo/assets/147942284/bd6b7c7a-fc5a-469f-810f-63f68f1bad5e">

