### PR TITLE
Fixed issue where header didn't load if the user didn't have a profile picture yet

### DIFF
--- a/scripts/security.js
+++ b/scripts/security.js
@@ -71,15 +71,22 @@ export async function getUserProfile() {
 async function getCCCollabProfile() {
   const bearerToken = await getBearerToken();
   const url = await getCcCollabUrl();
-  return await fetchCached(
-    `https://${url}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: bearerToken,
+
+  //If this fails, we want to return something. fetchCached will halt.
+  try{
+    return await fetchCached(
+      `https://${url}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: bearerToken,
+        },
       },
-    },
-  );
+    );
+  } catch (error) {
+    // fetchCached will log the error if it fails
+    return null;
+  }
 }
 
 export async function getAvatarUrl() {


### PR DESCRIPTION
JIRA: DXI-26839

Test URLs: https://dxi-26839--adobe-gmo--hlxsites.hlx.page/qa/assets

New users do not have a profile picture yet. fetchCached apparently will halt instead of returning undefined.

