### PR TITLE
add checks for null 'review link' and 'final asset'

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -486,9 +486,10 @@ async function buildTableRow(deliverableJson, kpi, createHidden) {
         <div class='property table-column column2 deliverable-type'>${checkBlankString(typeLabel)}</div>
         <div class='property table-column column3 platforms'></div>
         <div class='property table-column column4 review-link'>
-            <a href="${deliverableJson.reviewLink}" class="campaign-link" target="_blank">Review Link</a>
+            ${deliverableJson.reviewLink ? '<a href="' + deliverableJson.reviewLink + '"target="_blank" class="campaign-link">Review Link</a> ': "Not Available"}
         </div>
         <div class='property table-column column5'>
+            ${deliverableJson.linkedFolderLink ? '<a href="' + deliverableJson.linkedFolderLink + '"target="_blank" class="campaign-link">Final Asset</a> ': "Not Available"}
         </div>
         <div class='property table-column column7 justify-center'>
             <div class='status-wrapper'>
@@ -508,14 +509,6 @@ async function buildTableRow(deliverableJson, kpi, createHidden) {
         </div>
         <div class='property table-column column9'>${checkBlankString(deliverableJson.driver)}</div>
     `;
-    if (!(deliverableJson.linkedFolderLink == null)) {
-        const finalAssetLink = document.createElement('a');
-        finalAssetLink.href = deliverableJson.linkedFolderLink;
-        finalAssetLink.classList.add('campaign-link');
-        finalAssetLink.target = '_blank';
-        finalAssetLink.textContent = "Final Asset";
-        dataRow.querySelector('.column5').appendChild(finalAssetLink);
-    }
     createPlatformString(deliverableJson.platforms, dataRow);
     return dataRow;
 }


### PR DESCRIPTION
Fix issue where deliverables are showing invalid 'Review Links' when the reviewLink property is not populated. Also refactored the 'Final Asset' logic to use the same.

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-98992--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/program-details?programName=Express_Express%20for%20Business%20Launch&programID=66466a56027b70c2ee6edd2f027cc68a
