### PR TITLE
ASSETS-88918 : [Issue] Reset Filters button is not working intermittently

### DIFF
--- a/blocks/gmo-program-header/gmo-program-header.js
+++ b/blocks/gmo-program-header/gmo-program-header.js
@@ -126,6 +126,8 @@ export default async function decorate(block) {
     });
 
     initializeDropdowns();
+    // Attach event listeners for the dropdowns and reset filters
+    attachEventListeners();
     decorateIcons(block);
     document.addEventListener('click', handleClickOutside);
 }


### PR DESCRIPTION
https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/task/666a109a005068cb816b843c137f225e/overview

Test URLs:
<!--- For now you shouldn't add a path other than /sample-public-site. We can start changing -->
<!--- the URL after we've figured out how to run the CI on pages that require authentication. -->
<!--- /sample-public-site doesn't require authentication, so this is a way for us to ensure -->
<!--- that Franklin's CI (which we can't configure directly) will pass-->

https://assets-88918--adobe-gmo--hlxsites.hlx.page/marketing-dashboard
