### PR TITLE
ASSETS-72026 : Use taskStatus CF for mapping to get the task status label

### DIFF
--- a/scripts/program-calendar.js
+++ b/scripts/program-calendar.js
@@ -1,10 +1,11 @@
-import { checkBlankString } from './shared-program.js';
+import { checkBlankString, getMappingArray } from './shared-program.js';
 import { searchAsset } from '../../scripts/assets.js';
 
 let deliverables, deliverableMapping;
 let viewStart, viewEnd;
 const startDateProp = 'deliverableProjectStartDate';
 const endDateProp = 'deliverableProjectEndDate';
+const taskStatusMappings = await getMappingArray('taskStatus');
 
 export async function buildCalendar(dataObj, block, type, mappingArray, period) {
     if (!deliverables) deliverables = dataObj.data.deliverableList.items;
@@ -127,6 +128,10 @@ export async function buildCalendar(dataObj, block, type, mappingArray, period) 
             itemEl.classList.add('item');
             itemEl.style.marginLeft = startPctDiff + '%';
 
+            // Find the corresponding color code from the taskStatusMappings array
+            const statusMapping = taskStatusMappings.find(mapping => mapping.value === item.taskStatus);
+            const colorCode = statusMapping ? `#${statusMapping['color-code']}` : 'green'; // Default to green if not found
+
             // Create a placeholder for the thumbnail
             itemEl.innerHTML = `
                 <div class="color-tab"></div>
@@ -135,7 +140,7 @@ export async function buildCalendar(dataObj, block, type, mappingArray, period) 
                         <div class="info">
                             <div class="thumbnail"></div>
                             <div class="name" title="${item.deliverableName}">${item.deliverableName}</div>
-                            <div class="item-status" data-status="${checkBlankString(item.taskStatus)}"></div>
+                            <div class="item-status" data-status="${checkBlankString(item.taskStatus)}" style="background-color: ${colorCode};"></div>
                         </div>
                     </div>
                     <div class="content-row bottom">

--- a/scripts/program-calendar.js
+++ b/scripts/program-calendar.js
@@ -7,6 +7,11 @@ const startDateProp = 'deliverableProjectStartDate';
 const endDateProp = 'deliverableProjectEndDate';
 const taskStatusMappings = await getMappingArray('taskStatus');
 
+// Helper function to get task status mapping
+function getTaskStatusMapping(taskStatus) {
+    return taskStatusMappings.find(mapping => mapping.value === taskStatus) || {};
+}
+
 export async function buildCalendar(dataObj, block, type, mappingArray, period) {
     if (!deliverables) deliverables = dataObj.data.deliverableList.items;
     if (!deliverableMapping) deliverableMapping = await mappingArray;
@@ -129,8 +134,8 @@ export async function buildCalendar(dataObj, block, type, mappingArray, period) 
             itemEl.style.marginLeft = startPctDiff + '%';
 
             // Find the corresponding color code from the taskStatusMappings array
-            const statusMapping = taskStatusMappings.find(mapping => mapping.value === item.taskStatus);
-            const colorCode = statusMapping ? `#${statusMapping['color-code']}` : 'green'; // Default to green if not found
+            const statusMapping = getTaskStatusMapping(item.taskStatus);
+            const { text: statusText = 'Unknown Status', 'color-code': colorCode = 'green' } = statusMapping;
 
             // Create a placeholder for the thumbnail
             itemEl.innerHTML = `
@@ -140,7 +145,11 @@ export async function buildCalendar(dataObj, block, type, mappingArray, period) 
                         <div class="info">
                             <div class="thumbnail"></div>
                             <div class="name" title="${item.deliverableName}">${item.deliverableName}</div>
-                            <div class="item-status" data-status="${checkBlankString(item.taskStatus)}" style="background-color: ${colorCode};"></div>
+                            <div class="item-status"
+                                 data-status="${checkBlankString(item.taskStatus)}"
+                                 style="background-color: #${colorCode};"
+                                 title="${statusText}">
+                            </div>
                         </div>
                     </div>
                     <div class="content-row bottom">


### PR DESCRIPTION
https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/task/669e7376000bcb720f2ab0c99252f216/overview

Test URLs:

- Before: https://assets-72024--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/program-details?programName=Illustrator%20June%20Release&programID=662fed0d0289b3f642e78577cffc0dd4

- After:  https://assets-72026--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/program-details?programName=Illustrator%20June%20Release&programID=662fed0d0289b3f642e78577cffc0dd4

Authoring

Edited file drafts/mdickson/sites-config.xlsx file worksheet shared-query-fragments

Has the new entry

mapping-Type    path
taskStatus.           /content/dam/gmo-cf/en/wf-picklist-data-source/taskStatus

![Screenshot 2024-08-02 at 12 30 29 PM](https://github.com/user-attachments/assets/93f98da0-9371-470b-b86a-e765d4092e11)
