### PR TITLE
Update on CF and GraphQL Rename field categories to productGroup

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.css
+++ b/blocks/gmo-program-details/gmo-program-details.css
@@ -112,7 +112,7 @@ body {
     margin-left: 16px;
 }
 
-.header-row3 .icon-categories {
+.header-row3 .icon-productGroup {
     width: 16px;
     height: 16px;
     background-image: url('/icons/folderOpenOutline.svg');
@@ -127,7 +127,7 @@ body {
     margin-left: 8px;
 }
 
-.header-row3 .categories {
+.header-row3 .productGroup {
     font: normal normal normal 14px/21px Adobe Clean;
     margin-left: 8px;
 }

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -293,10 +293,10 @@ function buildHeader(program, queryVars) {
             <span class="release-tier">Release Tier: ${program.releaseTier || "Not Available"}</span>
         </div>`;
 
-    const categories = `
+    const productGroup = `
         <div class="header-row3">
-            <span class="icon-categories"></span>
-            <span class="categories">${program.categories && program.categories.length > 0 ? program.categories.join(', ') : "Not Available"}</span>
+            <span class="icon-productGroup"></span>
+            <span class="productGroup">${program.productGroup && program.productGroup.length > 0 ? program.productGroup.join(', ') : "Not Available"}</span>
         </div>`;
 
     headerWrapper.innerHTML = `
@@ -311,7 +311,7 @@ function buildHeader(program, queryVars) {
               ${date}
               ${driverField}
               ${releaseTier}
-              ${categories}
+              ${productGroup}
             </div>
         </div>
     `


### PR DESCRIPTION
WF Task
https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/task/66b6328d000cba739fb7fda1babe537f/overview

Test URLs:

https://assets-72028--adobe-gmo--hlxsites.hlx.page/qa/program-details?programName=Parent%20Brief%20%7C%20New%20HCV%20Fields&programID=66b27b53000210973416dedb277e01c3