### PR TITLE
display msg when no deliverables in calendar

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.css
+++ b/blocks/gmo-program-details/gmo-program-details.css
@@ -189,6 +189,12 @@ body {
 }
 .tab.calendar {
     margin-top:10px;
+    & > .no-data-msg {
+        height: 100px;
+        margin-top: 15px;
+        display: flex;
+        align-items: center;
+    }
     & > .control-wrapper {
         height: 32px;
         padding-top: 1px;

--- a/scripts/program-calendar.js
+++ b/scripts/program-calendar.js
@@ -28,6 +28,14 @@ export async function buildCalendar(dataObj, block, type, mappingArray, period) 
     const currentDate = new Date();
     const currentYear = currentDate.getFullYear();
 
+    // if there are no deliverables, display msg to user and end construction.
+    if (deliverables.length === 0) {
+        const calendarTab = document.querySelector('.calendar.tab');
+        calendarTab.innerHTML = `
+            <div class="no-data-msg">Required Data is Unavailable.</div>
+        `;
+        return;
+    }
 
     // get start of the view
     viewStart = getTimeBounds(deliverables, "start", startDateProp);


### PR DESCRIPTION
Add a message to the calendar tab that indicates there are no deliverables to be shown.

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-98992--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/program-details?programName=MPgM%20Training%20Request%20-%20Demo&programID=66731b7e0ac4b41af639322d597ece3d
