### PR TITLE
use current year in initial block, update msg

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -89,6 +89,8 @@ export default async function decorate(block) {
     const audiences = buildAudienceList(program).outerHTML;
     const artifactLinks = buildArtifactLinks(program).outerHTML;
 
+    const currentYear = new Date().getFullYear();
+
     // Inject the additional HTML content
     block.querySelector('.main-body-wrapper').innerHTML += `
         <div class="tab-wrapper">
@@ -189,7 +191,7 @@ export default async function decorate(block) {
                             <img class="right" data-direction="right" src="/icons/chevron-right.svg"></img>
                         </div>
                     </div>
-                    <div class="current-year" data-quarter="1" data-year="2024">2024</div>
+                    <div class="current-year" data-quarter="1" data-year="${currentYear}">${currentYear}</div>
                 </div>
                 <div class="right-controls">
                     <div class="today-button">Today</div>

--- a/scripts/program-calendar.js
+++ b/scripts/program-calendar.js
@@ -32,7 +32,7 @@ export async function buildCalendar(dataObj, block, type, mappingArray, period) 
     if (deliverables.length === 0) {
         const calendarTab = document.querySelector('.calendar.tab');
         calendarTab.innerHTML = `
-            <div class="no-data-msg">Required Data is Unavailable.</div>
+            <div class="no-data-msg">Required Data is Unavailable for this view.</div>
         `;
         return;
     }


### PR DESCRIPTION
- main js for details block now programmatically retrieves current year
- updated missing data msg for calendar view

Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/) your PR is for, as well as a description of your changes:

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-72090--adobe-gmo--hlxsites.hlx.page/program-details?programName=Summit%202025%20CSC%20Project&programID=66aa945b075a9e4cc04e149f1d72fb8c#
