### PR TITLE
Fix calendar task thumbnails

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.css
+++ b/blocks/gmo-program-details/gmo-program-details.css
@@ -547,6 +547,7 @@ body {
                     background-color: lightgray;
                     border-radius: 4px;
                     margin-right: 5px;
+                    overflow: hidden;
                 }
                 & .link {
                     margin-right: 10px;


### PR DESCRIPTION
Setting a max-height skews the aspect ratio and sometimes shows the gray default background. With overflow: hidden you can still get an idea of what the thumbnail is without having it look distorted.

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-72091--adobe-gmo--hlxsites.hlx.page/program-details?programName=Stock%20Q3%20Influencers&programID=66aa82c402e3be87aa22c972cd8187d7#
