### PR TITLE
Fix date validity checks

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -774,7 +774,7 @@ async function buildCalendar(dataObj, block, type, mappingArray, period) {
 
     // get end of the view
     viewEnd = getTimeBounds(calendarDeliverables, "end", endDateProp);
-    if (!(isValidDate(viewEnd)) || viewEnd.getFullYear() === 1969) {
+    if (!(isValidDate(viewEnd)) || viewEnd <= 0) {
         viewEnd = new Date(viewStart);
         viewEnd.setMonth(viewStart.getMonth() + 1);
     }
@@ -820,9 +820,9 @@ async function buildCalendar(dataObj, block, type, mappingArray, period) {
 
         // find the earliest date- this is how we set the position for the group against the calendar
         let earliestStartDate = getTimeBounds(matchedItems, "start", startDateProp);
-        earliestStartDate = (!(isValidDate(earliestStartDate)) || earliestStartDate.getFullYear() === 1969) ? new Date(viewStart) : earliestStartDate;
+        earliestStartDate = (!(isValidDate(earliestStartDate)) || earliestStartDate <= 0) ? new Date(viewStart) : earliestStartDate;
         let latestEndDate = getTimeBounds(matchedItems, "end", endDateProp);
-        latestEndDate = (!(isValidDate(latestEndDate)) || latestEndDate.getFullYear() === 1969) ? new Date(viewEnd) : latestEndDate;
+        latestEndDate = (!(isValidDate(latestEndDate)) || latestEndDate <= 0) ? new Date(viewEnd) : latestEndDate;
         const startMonth = (earliestStartDate.getUTCMonth()); // getMonth returns 0-11 but this is desirable
         const startDay = (earliestStartDate.getUTCDate() - 1); // if at start of month, we don't want to add any more margin
         const endMonth = (latestEndDate.getUTCMonth());


### PR DESCRIPTION
Change remaining validity checks to be timezone-agnostic.

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-72094--adobe-gmo--hlxsites.hlx.page/drafts/mdickson/program-details?programName=4/23%20Release:%20MAX%20London%20Ps%20+%20Id&programID=65d7e64d029a5bfffe1e807f346a0b5a
