### PR TITLE
Visual bugfixes for calendar view

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.css
+++ b/blocks/gmo-program-details/gmo-program-details.css
@@ -454,6 +454,7 @@ body {
                 max-width: 100%; /* Adjusts the width to leave space for the group count */
                 display: inline-block; /* Ensures the element respects the max-width */
                 vertical-align: middle; /* Aligns it properly with other inline elements */
+                min-width: 52px; /* Ensure at least 5 characters show */
             }
             & .group-count {
                 position: absolute;
@@ -596,8 +597,8 @@ body {
                     background-color: #9D64E1;
                 }
             }
-            &#group5 {
-                background-color: #168a4a;
+            &.color5 {
+                background-color: #95dfb696;
                 border: 1px solid #24a25d;
                 & .group-header {
                     background-color: #137941;

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -929,8 +929,7 @@ async function buildCalendar(dataObj, block, type, mappingArray, period) {
         });
 
         contentWrapper.appendChild(groupEl);
-        groupIndex +=1;
-
+        groupIndex = (groupIndex === 5) ? 1 : groupIndex + 1;
     };
 
     calendarEl.appendChild(contentWrapper);

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -44,14 +44,15 @@ export default async function decorate(block) {
     // Wait for program data to render the actual header
     const programData = await executeQuery(programQueryString);
     const program = programData.data.programList.items[0];
-    const header = buildHeader(program, queryVars).outerHTML;
-
-    // Update the header with the actual data
-    block.querySelector('.placeholder-header').outerHTML = header;
 
     let imageObject = {imageUrl : '', imageAltText: '', assetCount: 0};
     let totalassets = 0;
-    if (program) {
+    let header = block.querySelector('.placeholder-header');
+
+    if (!(program === undefined)) {
+        const programHeader = buildHeader(program, queryVars).outerHTML;
+        // Update the header with the actual data
+        header.outerHTML = programHeader;
         try {
             imageObject = await searchAsset(program.programName, program.campaignName);
             if (imageObject) {
@@ -62,17 +63,17 @@ export default async function decorate(block) {
             console.error("Failed to load campaign image:", error);
         }
         decorateIcons(block);
-    }
-    else
-    {   //programName and campaignName is null
+    } else {
+        //programName and campaignName is null
+        header.textContent = 'Unable to retrieve program information.';
         block.innerHTML = `
         <div class="back-button">
             <span class="icon icon-back"></span>
             <span class="back-label">Back</span>
         </div>
         <div class="main-body-wrapper">
-            ${header}
-            <div class="no-data-msg">No data available.</div>
+            ${header.outerHTML}
+            <div class="no-data-msg">No program data available.</div>
         </div>
         `;
         try {

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -353,7 +353,7 @@ function insertImageIntoCampaignImg(block, imageObject) {
     imgElement.loading = 'lazy';
     imgElement.src = imageObject.imageUrl;
     imgElement.alt = imageObject.imageAltText;
-    campaignImgDiv.appendChild(imgElement);
+    if (campaignImgDiv) campaignImgDiv.appendChild(imgElement);
 }
 
 function switchTab(tab) {


### PR DESCRIPTION
- Adjust min width on group headings in calendar view
- Fix logic for assigning colors to groups in calendar view (cyan shouldn't show up, counter properly resets)

Test URLs:
- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-72096--adobe-gmo--hlxsites.hlx.page/program-details?programName=Adobe%20Express:%20Q3%20Run%20the%20Business&programID=6650eef505ebc8860981e6386f268d4d&path=/content/dam/gmo-cf/en/digital-media-dme/programs/adobe-express-q3-run-the-business-6650eef505ebc8860981e6386f268d4d
