### PR TITLE
Add ability to hide calendar tab via block config

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.css
+++ b/blocks/gmo-program-details/gmo-program-details.css
@@ -198,7 +198,8 @@ body {
     justify-content: space-between;
     flex-wrap: wrap;
     align-content: center;
-    width: 240px;
+    width: fit-content;
+    max-width: 240px;
     height: 50px;
     font: normal normal normal 14px/17px Adobe Clean;
     border-bottom: 2px solid #EAEAEA;
@@ -210,6 +211,9 @@ body {
             color: #323232;
             border-bottom: 2px solid #323232;
         }
+    }
+    & > div:not(:first-child) {
+        margin-left: 25px;
     }
 }
 

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -24,7 +24,6 @@ const thumbnailCache = {};
 
 export default async function decorate(block) {
     blockConfig = readBlockConfig(block);
-    console.log(blockConfig)
     block.innerHTML = ` `;
 
     const currentYear = new Date().getFullYear();

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -71,7 +71,7 @@ export default async function decorate(block) {
         { class: 'tab-wrapper'},
         div({ id: 'tab1toggle', class: 'tabBtn active', 'data-target': 'tab1'}, 'Overview'),
         div({ id: 'tab2toggle', class: 'tabBtn', 'data-target': 'tab2'}, 'Deliverables'),
-        div({ id: 'tab3toggle', class: `tabBtn ${hideCalendar ? 'inactive' : ''}`, 'data-target': 'tab3'}, 'Calendar'),
+        div({ id: 'tab3toggle', class: `tabBtn ${hideCalendar == 'true' ? 'inactive' : ''}`, 'data-target': 'tab3'}, 'Calendar'),
     );
 
     // overview tab

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -24,6 +24,7 @@ const thumbnailCache = {};
 
 export default async function decorate(block) {
     blockConfig = readBlockConfig(block);
+    console.log(blockConfig)
     block.innerHTML = ` `;
 
     const currentYear = new Date().getFullYear();
@@ -66,12 +67,13 @@ export default async function decorate(block) {
     );
 
     // tab wrapper
+    const hideCalendar = blockConfig.hidecalendar;
     const tabWrapper = div(
         { class: 'tab-wrapper'},
         div({ id: 'tab1toggle', class: 'tabBtn active', 'data-target': 'tab1'}, 'Overview'),
         div({ id: 'tab2toggle', class: 'tabBtn', 'data-target': 'tab2'}, 'Deliverables'),
-        div({ id: 'tab3toggle', class: 'tabBtn', 'data-target': 'tab3'}, 'Calendar'),
-        );
+        div({ id: 'tab3toggle', class: `tabBtn ${hideCalendar ? 'inactive' : ''}`, 'data-target': 'tab3'}, 'Calendar'),
+    );
 
     // overview tab
     const overviewTab = div(


### PR DESCRIPTION
Per feedback received during HCV dashboard demo, add the ability to hide the calendar tab.

To do this, add a line to the table in the `program-details.docx` doc called "hideCalendar" with value "true" or "false". Example:
![image](https://github.com/user-attachments/assets/56f8a513-dd37-496c-b36d-970b3273767a)

Test URLs:
- Before: https://rc--adobe-gmo--hlxsites.hlx.page/marketing-dashboard
- After: https://assets-98986--adobe-gmo--hlxsites.hlx.page/marketing-dashboard
