### PR TITLE
cherrypick calendar tab changes

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.css
+++ b/blocks/gmo-program-details/gmo-program-details.css
@@ -198,7 +198,8 @@ body {
     justify-content: space-between;
     flex-wrap: wrap;
     align-content: center;
-    width: 240px;
+    width: fit-content;
+    max-width: 240px;
     height: 50px;
     font: normal normal normal 14px/17px Adobe Clean;
     border-bottom: 2px solid #EAEAEA;
@@ -209,6 +210,9 @@ body {
         &.active {
             color: #323232;
             border-bottom: 2px solid #323232;
+        }
+        & > div:not(:first-child) {
+            margin-left: 25px;
         }
     }
 }

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -66,12 +66,13 @@ export default async function decorate(block) {
     );
 
     // tab wrapper
+    const hideCalendar = blockConfig.hidecalendar;
     const tabWrapper = div(
         { class: 'tab-wrapper'},
         div({ id: 'tab1toggle', class: 'tabBtn active', 'data-target': 'tab1'}, 'Overview'),
         div({ id: 'tab2toggle', class: 'tabBtn', 'data-target': 'tab2'}, 'Deliverables'),
-        div({ id: 'tab3toggle', class: 'tabBtn', 'data-target': 'tab3'}, 'Calendar'),
-        );
+        div({ id: 'tab3toggle', class: `tabBtn ${hideCalendar == 'true' ? 'inactive' : ''}`, 'data-target': 'tab3'}, 'Calendar'),
+    );
 
     // overview tab
     const overviewTab = div(


### PR DESCRIPTION
Per feedback received during HCV dashboard demo, add the ability to hide the calendar tab.

To do this, add a line to the table in the program-details.docx doc called "hideCalendar" with value "true" or "false". Example:
image

Test URLs:

Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
After: https://rc--adobe-gmo--hlxsites.hlx.page/marketing-dashboard
