### PR TITLE
Cherrypick taskstatus changes

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.css
+++ b/blocks/gmo-program-details/gmo-program-details.css
@@ -845,7 +845,6 @@ body {
         flex-direction: column;
         .collection-link {
             display: block;
-            white-space: nowrap;
         }
     }
 }
@@ -908,6 +907,7 @@ body {
         top: 0;
         & > .showhide-deliverables {
             margin-left: 10px;
+            margin-right: 5px;
         }
     }
 }
@@ -1066,7 +1066,11 @@ body {
 }
 
 .header.column1 {
-    margin-left: 16px;
+    margin-left: 12px;
+}
+
+.header.column5 {
+    margin-right: 42px;
 }
 
 .column3 {
@@ -1074,7 +1078,7 @@ body {
 }
 
 .column4 {
-    width: 110px;
+    width: 90px;
     margin-right: 40px;
 }
 
@@ -1106,9 +1110,13 @@ body {
     line-height: 1.2;
 }
 
+.column10 {
+    width: 120px;
+}
+
 .table-column {
     &:not(:last-child) {
-        margin-right: 45px;
+        margin-right: 30px;
     }
 }
 

--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -168,6 +168,7 @@ export default async function decorate(block) {
                 div({ class: 'header table-column column4' }, 'QA Files'),
                 div({ class: 'header table-column column5' }, 'Approved Collection Link(s)'),
                 div({ class: 'header table-column column7' }, 'Status Update'),
+                div({ class: 'header table-column column10' }, 'Task Status'),
                 div({ class: 'header table-column column8' }, 'Completion Date'),
                 div({ class: 'header table-column column9' }, 'Task Owner'),               
             ),
@@ -1010,6 +1011,7 @@ async function buildTableRow(deliverable, createHidden) {
                 ),
             )
         ),
+        div({ class: 'property table-column column10' }, checkBlankString(deliverable.taskStatus)),
         div({ class: 'property table-column column8 date-wrapper' },
             div({ class: 'completion-date' }, dateFormat(deliverable.taskCompletionDate)),
             deliverable.previousTaskCompletionDate
@@ -1062,8 +1064,8 @@ function createAssetLink(deliverable) {
 
 function parseCollectionName(rawString) {
     const collectionName = rawString;
-    const maxLength = 73;
-    const charsToShow = 34;
+    const maxLength = 67;
+    const charsToShow = 28;
     
     if (collectionName.length > maxLength) {
         const truncatedString = collectionName.slice(0, charsToShow) + "[...]" + collectionName.slice(-charsToShow);


### PR DESCRIPTION
Add an additional 'task status' column and required CSS changes to support

- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-98987--adobe-gmo--hlxsites.hlx.page/program-details?programName=Spring%20into%202025&programID=67856e8e095fed692da5d17914e58eb7&path=/content/dam/gmo-cf/en/digital-media-dme/programs/spring-into-2025-67856e8e095fed692da5d17914e58eb7
