### PR TITLE
ensure path capture group stops at #

### DIFF
--- a/blocks/gmo-program-details/gmo-program-details.js
+++ b/blocks/gmo-program-details/gmo-program-details.js
@@ -1158,7 +1158,7 @@ function attachListener(htmlElement) {
 
 function extractQueryVars() {
     const urlStr = window.location.href;
-    const pnRegex = /[?&]programName=([^&]+)&programID=([^&]+)(&path=([^&]+))?/;
+    const pnRegex = /[?&]programName=([^&]+)&programID=([^&]+)(&path=([^&#]+))?/;
     const match = urlStr.match(pnRegex);
     if (match && match[1] && match[2]) {
         const pName = decodeURIComponent(match[1]); // Removed the replace method


### PR DESCRIPTION
Update the regex that parses URL params to exclude trailing # (so links from Slack should work).

JIRA: ASSETS-00000

Test URLs:
- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-98988--adobe-gmo--hlxsites.hlx.page/program-details?programName=February%20L1%20Release_iPhone%20App%20GA&programID=667087ec00be4054816fbf84c5f104ce&path=/content/dam/gmo-cf/en/digital-media-dme/programs/september-l0-release-iphone-app-ga-667087ec00be4054816fbf84c5f104ce#
