### PR TITLE
refactor prev/next btn activation

### DIFF
--- a/blocks/gmo-program-list/gmo-program-list.js
+++ b/blocks/gmo-program-list/gmo-program-list.js
@@ -169,18 +169,42 @@ export default async function decorate(block, numPerPage = currentNumberPerPage,
 }
 
 function togglePaginationButtons() {
+    waitForElements('.footer-pagination-button', (footerPrev, footerNext) => {
+        if (!footerPrev || !footerNext) return;
+
+        if (currentPage > 1) {
+            footerPrev.classList.add('active');
+        } else {
+            footerPrev.classList.remove('active');
+        }
+
+        if (currentPage < totalPages) {
+            footerNext.classList.add('active');
+        } else {
+            footerNext.classList.remove('active');
+        }
+    });
+}
+
+function waitForElements(selector, callback) {
+    const observer = new MutationObserver(() => {
+        const footerPrev = document.querySelector('.footer-pagination-button.prev');
+        const footerNext = document.querySelector('.footer-pagination-button.next');
+
+        if (footerPrev && footerNext) {
+            observer.disconnect(); // Stop observing once elements are found
+            callback(footerPrev, footerNext);
+        }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    // Also check immediately in case elements already exist
     const footerPrev = document.querySelector('.footer-pagination-button.prev');
     const footerNext = document.querySelector('.footer-pagination-button.next');
-    if (currentPage > 1) {
-        footerPrev.classList.add('active');
-    } else {
-        footerPrev.classList.remove('active');
-    }
-
-    if (currentPage < totalPages) {
-        footerNext.classList.add('active');
-    } else {
-        footerNext.classList.remove('active');
+    if (footerPrev && footerNext) {
+        observer.disconnect();
+        callback(footerPrev, footerNext);
     }
 }
 


### PR DESCRIPTION
Address a bug where pagination buttons were being referenced before the DOM finished loading

JIRA: ASSETS-00000

Test URLs:
- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: http://assets-91001--adobe-gmo--hlxsites.hlx.page/marketing-dashboard
