### PR TITLE
defer filters processing

### DIFF
--- a/blocks/gmo-program-list/gmo-program-list.js
+++ b/blocks/gmo-program-list/gmo-program-list.js
@@ -101,7 +101,6 @@ export default async function decorate(block, numPerPage = currentNumberPerPage,
             const filterValue = decodeURIComponent(filterSource);
             graphQLFilter = JSON.parse(filterValue);
         }
-        displayFilterSelections(graphQLFilter);
     }
 
     const campaignPaginatedResponse = await graphqlAllCampaignsFilter(numPerPage, cursor,graphQLFilter);
@@ -146,6 +145,9 @@ export default async function decorate(block, numPerPage = currentNumberPerPage,
     togglePaginationButtons();
 
     decorateIcons(block);
+
+    // defer filters processing until nearly everything else is done
+    if (isBack || isShared) displayFilterSelections(graphQLFilter);
 
     hideLoadingOverlay(block);
 


### PR DESCRIPTION
Solve race condition in processing filters where function would occasionally run before the DOM elements it referenced would finish loading

JIRA: ASSETS-00000

Test URLs:
- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-91003--adobe-gmo--hlxsites.hlx.page/marketing-dashboard
