### PR TITLE
Filter programs flagged as 'test' or 'demo'

### DIFF
--- a/blocks/gmo-program-list/gmo-program-list.js
+++ b/blocks/gmo-program-list/gmo-program-list.js
@@ -52,10 +52,7 @@ let currentNumberPerPage = DEFAULT_ITEMS_PER_PAGE;
 let currentGraphqlFilter = {};
 let totalPages = 0;
 //Get Campaign Count for pagination
-let baseFilterArray = {}; 
-baseFilterArray['projectUse'] = { _logOp: 'OR', _expressions: [] }
-baseFilterArray['projectUse']._expressions.push({ value: null, _operator: 'EQUALS', _ignoreCase: true });
-baseFilterArray['projectUse']._expressions.push({ value: 'Prod', _operator: 'EQUALS', _ignoreCase: true });
+let baseFilterArray = addProjectUseFilter({}); 
 let campaignCount = graphqlCampaignCount(baseFilterArray);
 let blockConfig;
 
@@ -71,9 +68,7 @@ document.addEventListener('gmoCampaignListBlock', async function() {
     currentGraphqlFilter= generateFilterJSON(graphQLFilterArray);
 
     // add projectUse filter to filter non-prod projects
-    currentGraphqlFilter['projectUse'] = { _logOp: 'OR', _expressions: [] }
-    currentGraphqlFilter['projectUse']._expressions.push({ value: null, _operator: 'EQUALS', _ignoreCase: true });
-    currentGraphqlFilter['projectUse']._expressions.push({ value: 'Prod', _operator: 'EQUALS', _ignoreCase: true });
+    currentGraphqlFilter = addProjectUseFilter(currentGraphqlFilter);
 
     const block = document.querySelector('.gmo-program-list.block');
     //Get Campaign Count for pagination
@@ -653,4 +648,11 @@ function displayFilterSelections(filterObj) {
             toggleOption(value, key);
         }
     }
+}
+
+function addProjectUseFilter(filterArray = {}) {
+    filterArray['projectUse'] = { _logOp: 'OR', _expressions: [] }
+    filterArray['projectUse']._expressions.push({ value: null, _operator: 'EQUALS', _ignoreCase: true });
+    filterArray['projectUse']._expressions.push({ value: 'Prod', _operator: 'EQUALS', _ignoreCase: true });
+    return filterArray;
 }

--- a/blocks/gmo-program-list/gmo-program-list.js
+++ b/blocks/gmo-program-list/gmo-program-list.js
@@ -64,7 +64,12 @@ document.addEventListener('gmoCampaignListBlock', async function() {
       graphQLFilterArray.push({type:'programName', value:searchInputValue, operator:'='})
     }
 
+    // add param to filter out test projects
+    graphQLFilterArray.push({ type: 'projectUse', value: 'Test', operator : 'EQUALS_NOT' });
+    graphQLFilterArray.push({ type: 'projectUse', value: 'Demo', operator : 'EQUALS_NOT' });
+
     currentGraphqlFilter= generateFilterJSON(graphQLFilterArray);
+    //console.log(currentGraphqlFilter);
     const block = document.querySelector('.gmo-program-list.block');
     //Get Campaign Count for pagination
     campaignCount = graphqlCampaignCount(currentGraphqlFilter);
@@ -108,9 +113,24 @@ export default async function decorate(block, numPerPage = currentNumberPerPage,
         }
 
         clearStoredSearch(); // Clear stored search after processing
+    } else {
+        console.log('Not shared/back')
+        console.log(graphQLFilter);
+        console.log(Object.keys(graphQLFilter).length === 0);
+        if (Object.keys(graphQLFilter).length === 0) {
+            //graphQLFilterArray.push({ type: 'projectUse', value: 'Test', operator : 'EQUALS_NOT' });
+            //graphQLFilterArray.push({ type: 'projectUse', value: 'Demo', operator : 'EQUALS_NOT' });
+            graphQLFilter['projectUse'] = { _expressions: [] }
+            graphQLFilter['projectUse']._expressions.push({ value: 'Test', _operator: 'EQUALS_NOT', _ignoreCase: true });
+            graphQLFilter['projectUse']._expressions.push({ value: 'Demo', _operator: 'EQUALS_NOT', _ignoreCase: true });
+            //const expression = { value: 'Test', _operator: 'EQUALS_NOT', _ignoreCase: true }
+        }
+        // add 'projectUse' param to filter test projects
+        //graphQLFilter.push({ type: 'projectUse', value: 'Prod', operator : '=' });
+        //graphQLFilter.push({ type: 'projectUse', value: 'Test', operator : 'EQUALS_NOT' });
     }
 
-    const campaignPaginatedResponse = await graphqlAllCampaignsFilter(numPerPage, cursor,graphQLFilter);
+    const campaignPaginatedResponse = await graphqlAllCampaignsFilter(numPerPage, cursor, graphQLFilter);
     const campaigns = campaignPaginatedResponse.data.programPaginated.edges;
     currentPageInfo = campaignPaginatedResponse.data.programPaginated.pageInfo;
     //Current cursor used in previous page logic

--- a/scripts/graphql.js
+++ b/scripts/graphql.js
@@ -40,13 +40,11 @@ export function graphqlCampaignCount(filter = {}) {
 }
 
 export async function graphqlAllCampaignsFilter(first,cursor,filter) {
-  if (filter) console.log(filter);
   const queryName = 'getAllCampaigns';
   const encodedFirst = encodeURIComponent(first);
   const encodedSemiColon = encodeURIComponent(';');
   const encodedCursor = encodeURIComponent(cursor);
   const encodedFilter = encodeURIComponent(JSON.stringify(filter));
-  console.log(encodedFilter);
   const graphqlEndpoint = `${baseApiUrl}/${projectId}/${queryName}${encodedSemiColon}first=${encodedFirst}${encodedSemiColon}cursor=${encodedCursor}${encodedSemiColon}filter=${encodedFilter}`;
   //Performance logging
   const startTime = performance.now();

--- a/scripts/graphql.js
+++ b/scripts/graphql.js
@@ -40,11 +40,13 @@ export function graphqlCampaignCount(filter = {}) {
 }
 
 export async function graphqlAllCampaignsFilter(first,cursor,filter) {
+  if (filter) console.log(filter);
   const queryName = 'getAllCampaigns';
   const encodedFirst = encodeURIComponent(first);
   const encodedSemiColon = encodeURIComponent(';');
   const encodedCursor = encodeURIComponent(cursor);
   const encodedFilter = encodeURIComponent(JSON.stringify(filter));
+  console.log(encodedFilter);
   const graphqlEndpoint = `${baseApiUrl}/${projectId}/${queryName}${encodedSemiColon}first=${encodedFirst}${encodedSemiColon}cursor=${encodedCursor}${encodedSemiColon}filter=${encodedFilter}`;
   //Performance logging
   const startTime = performance.now();
@@ -159,6 +161,11 @@ export function generateFilterJSON(filterParams) {
       if (param.operator === "CONTAINS") {
           expression._operator = "CONTAINS";
           expression._ignoreCase = true;
+      }
+      // handle not-equal operator (!==)
+      if (param.operator === "EQUALS_NOT") {
+        expression._operator = "EQUALS_NOT";
+        expression._ignoreCase = true;
       }
 
       // Add the expression object to the _expressions array for the corresponding parameter name


### PR DESCRIPTION
Update the filters in the program list to make use of the new 'projectUse' parameter, and to filter programs that are marked as 'test' and 'demo' from the dashboard.

Test URLs:
- Before: https://main--assets-distribution-portal--adobe.hlx.page/sample-public-site
- After: https://assets-91005--adobe-gmo--hlxsites.hlx.page/marketing-dashboard
